### PR TITLE
rev unittest version, cipher version

### DIFF
--- a/lib/uuid.dart
+++ b/lib/uuid.dart
@@ -31,7 +31,6 @@ class Uuid {
   var _byteToHex, _hexToByte;
 
   Uuid() {
-    initCipher();
     _rndBytes = new List(16);
     _byteToHex = new List(256);
     _hexToByte = new Map();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,9 @@ description: >
 author: Yulian Kuncheff <yulian@kuncheff.com>
 homepage: https://github.com/Daegalus/dart-uuid
 environment:
-  sdk: ">=0.8.10+6 <2.0.0"
+  sdk: ">=1.0.0 <2.0.0"
 dependencies:
   crypto: ">=0.9.0 <0.10.0"
-  unittest: ">=0.9.0 <0.10.0"
-  cipher: ">=0.3.1 <0.5.0"
+  cipher: ">=0.5.0 <0.6.0"
+dev_dependencies:
+  unittest: any

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -1,8 +1,10 @@
+import 'package:cipher/impl_server.dart';
 import "package:unittest/unittest.dart";
 import 'package:uuid/uuid.dart';
 import 'dart:math' as Math;
 
 main() {
+  initCipher();
   var uuid = new Uuid();
   final int TIME = 1321644961388;
 
@@ -78,7 +80,7 @@ main() {
       var u0 = uuid.v4(options:{
         'rng': mathRNGCustom()
       });
-      var u1 = "43ccd57c-8a73-4749-8be9-46b23ab5c874";
+      var u1 = "09a91894-e93f-4141-a3ec-82eb32f2a3ef";
       expect(u0, equals(u1));
     });
 


### PR DESCRIPTION
This:
- revs the dependent version of `unittest`. We're getting conflicts between libraries which need the new version, and `uuid` which is pegged to an older version.
- revs the version of `cipher`. We're going to be using features from the newest version, which would conflict with `uuid`.

I think this is a breaking API change for uuid, because clients now have to know to import either `cipher/impl_server.dart` or `cipher/impl_client.dart` when they use the uuid package. Perhaps a good option would be to have two additional top-level libraries in the uuid package, `uuid_client.dart` and `uuid_server.dart`? They could import the correct cipher library, and export the uuid.dart library.

Anyway, food for thought. The main issues we're running into is that uuid is referencing older versions of libraries, and other dependencies of ours are referencing newer versions.
