### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: uuid
-version: 0.3.0
+version: 0.3.1
 description: >
   RFC4122(v1,v4,v5) UUID Generator and Parser.
 author: Yulian Kuncheff <yulian@kuncheff.com>
@@ -8,6 +8,6 @@ environment:
   sdk: ">=1.0.0 <2.0.0"
 dependencies:
   crypto: ">=0.9.0 <0.10.0"
-  cipher: ">=0.6.0 <0.7.0"
+  cipher: ">=0.7.0 <0.8.0"
 dev_dependencies:
   unittest: any


### PR DESCRIPTION
Change the cipher dependency to pull in the new version (0.7.0). This will let people who use both cipher and uuid to upgrade to the new version of cipher :)
