### PR TITLE
Fix a "Duplicated library name 'Uuid'." Dart2JS warning

### DIFF
--- a/lib/src/uuid.dart
+++ b/lib/src/uuid.dart
@@ -1,4 +1,3 @@
-library Uuid;
 import 'dart:math' as Math;
 import 'package:crypto/crypto.dart';
 import 'package:cipher/cipher.dart';

--- a/lib/uuid_client.dart
+++ b/lib/uuid_client.dart
@@ -1,19 +1,15 @@
-library Uuid;
-import 'dart:math' as Math;
-import 'package:crypto/crypto.dart';
-import 'package:cipher/cipher.dart';
+library uuid_client;
+
+import 'src/uuid.dart';
 import 'package:cipher/impl/client.dart';
-import 'dart:typed_data';
-import 'uuid.dart';
 
 class Uuid extends UuidBase {
 
-  // RFC4122 provided namespaces for v3 and v5 namespace based UUIDs
-  static const NAMESPACE_DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
-  static const NAMESPACE_URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
-  static const NAMESPACE_OID = '6ba7b812-9dad-11d1-80b4-00c04fd430c8';
-  static const NAMESPACE_X500= '6ba7b814-9dad-11d1-80b4-00c04fd430c8';
-  static const NAMESPACE_NIL = '00000000-0000-0000-0000-000000000000';
+  static const NAMESPACE_DNS = UuidBase.NAMESPACE_DNS;
+  static const NAMESPACE_URL = UuidBase.NAMESPACE_URL;
+  static const NAMESPACE_OID = UuidBase.NAMESPACE_OID;
+  static const NAMESPACE_X500= UuidBase.NAMESPACE_X500;
+  static const NAMESPACE_NIL = UuidBase.NAMESPACE_NIL;
 
   Uuid() : super() {
     this.initCipher(initCipher);

--- a/lib/uuid_server.dart
+++ b/lib/uuid_server.dart
@@ -1,19 +1,15 @@
-library Uuid;
-import 'dart:math' as Math;
-import 'package:crypto/crypto.dart';
-import 'package:cipher/cipher.dart';
+library uuid_server;
+
+import 'src/uuid.dart';
 import 'package:cipher/impl/base.dart';
-import 'dart:typed_data';
-import 'uuid.dart';
 
 class Uuid extends UuidBase {
 
-  // RFC4122 provided namespaces for v3 and v5 namespace based UUIDs
-  static const NAMESPACE_DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
-  static const NAMESPACE_URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
-  static const NAMESPACE_OID = '6ba7b812-9dad-11d1-80b4-00c04fd430c8';
-  static const NAMESPACE_X500= '6ba7b814-9dad-11d1-80b4-00c04fd430c8';
-  static const NAMESPACE_NIL = '00000000-0000-0000-0000-000000000000';
+  static const NAMESPACE_DNS = UuidBase.NAMESPACE_DNS;
+  static const NAMESPACE_URL = UuidBase.NAMESPACE_URL;
+  static const NAMESPACE_OID = UuidBase.NAMESPACE_OID;
+  static const NAMESPACE_X500= UuidBase.NAMESPACE_X500;
+  static const NAMESPACE_NIL = UuidBase.NAMESPACE_NIL;
 
   Uuid() : super() {
     this.initCipher(initCipher);


### PR DESCRIPTION
The cause of the warning was that previously
both uuid.dart and uuid_client.dart declared
"library uuid;".

This commit changes the package structure to
make it work more like the "chrome" package,
i.e. move uuid.dart out of the way into a
subfolder and declare "library uuid_server;"
and "library uuid_client;" in the respective
files.

Additionally, it removes some extraneous
imports.
