### PR TITLE
Updated SDK constraints to '>=2.0.0 <3.0.0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v1.0.2+1
+* Updated Dart SDK constraints to version '>=2.0.0 <3.0.0'.
+
 v1.0.2
 * Fix constants breaking in Dart 1.x, need to be backwards compatible. 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: uuid
-version: 1.0.2
+version: 1.0.2+1
 description: >
   RFC4122 (v1, v4, v5) UUID Generator and Parser for all Dart platforms (Web, VM, Flutter)
 author: Yulian Kuncheff <yulian@kuncheff.com>
 homepage: https://github.com/Daegalus/dart-uuid
 environment:
-  sdk: ">=1.0.0 <2.0.0"
+  sdk: ">=2.0.0 <3.0.0"
 dependencies:
   crypto: ">=1.0.0 <3.0.0"
   convert: ">=1.0.0 <3.0.0"


### PR DESCRIPTION
Code had been updated for Dart 2.0, but the pubspec was still referring to a version <2.0.0.  Updated lower and upper constraints accordingly.