### PR TITLE
bad timestamp

### DIFF
--- a/lib/uuid.dart
+++ b/lib/uuid.dart
@@ -183,7 +183,7 @@ class Uuid {
     buf[i++] = tl & 0xff;
 
     // time mid
-    var tmh = (mSecs ~/ 0x100000000 * 10000) & 0xfffffff;
+    var tmh = (mSecs / 0x100000000 * 10000).floor() & 0xfffffff;
     buf[i++] = tmh >> 8 & 0xff;
     buf[i++] = tmh & 0xff;
 


### PR DESCRIPTION
The timestamp calculation was not working correctly. The ~/ was messing it up.
In the end, when I retrieved the timestamp from the TImeUUID, it was not the same that originated it.

I changed it to a floor and it is working correctly.

The code below prints the incorrect date retrieved from the uuid:

```
        timestampFromTimeUuid(String uuid) {
		var uuid_arr = uuid.split( '-' ),
				time_str = [
					uuid_arr[ 2 ].substring( 1 ),
					uuid_arr[ 1 ],
					uuid_arr[ 0 ]
				].join( '' );
		return int.parse( time_str, radix: 16 );
	}

        dateFromTimeUuid(String uuid) {
		var int_time = timestampFromTimeUuid( uuid ) - 122192928000000000,
				int_millisec = ( int_time / 10000 ).floor();
		return DateTime.fromMillisecondsSinceEpoch( int_millisec ).toUtc();
	}
print('${dateFromTimeUuid(uuid.v1(options: {
    'node': [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
    'clockSeq': 0x1234,
    'mSecs': 1560474042512, // this timestamp is for 2019-06-14 01:00:42.512Z
    'nSecs': 5678
  }))}');
```