### PR TITLE
Change title to name of package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/Daegalus/dart-uuid.svg?branch=master)](https://travis-ci.org/Daegalus/dart-uuid)
 
-# dart-uuid
+# uuid
 
 **Version 2.0.0 has breaking API changes. Please review them below.**
 


### PR DESCRIPTION
I suggest changing the title of the readme to the name of the actual Dart package to avoid (minor but unnecessary) confusion.