### PR TITLE
Migrate to null safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: dart
 dart:
   - dev
-  - stable
+#  - stable
+  - beta
 
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v2.3.0-nullsafety.0
+
+* Migrate package to null-safety, increase minimum SDK version to 2.12
+
 v2.2.1 & v2.2.2
 
 * Update pedantic analyzer options, fix linting issues, and increase SDK minimium to 2.2 to support set literals

--- a/lib/uuid.dart
+++ b/lib/uuid.dart
@@ -1,5 +1,7 @@
 library uuid;
 
+import 'dart:typed_data';
+
 import 'uuid_util.dart';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:convert/convert.dart' as convert;
@@ -74,7 +76,7 @@ class Uuid {
     var i = offset, ii = 0;
 
     // Create a 16 item buffer if one hasn't been provided.
-    buffer = (buffer != null) ? buffer : List<int>.filled(16, 0);
+    buffer = (buffer != null) ? buffer : Uint8List(16);
 
     // Convert to lowercase and replace all hex with bytes then
     // string.replaceAll() does a lot of work that I don't need, and a manual
@@ -126,7 +128,7 @@ class Uuid {
   /// http://tools.ietf.org/html/rfc4122.html#section-4.2.2
   String v1({Map<String, dynamic>? options}) {
     var i = 0;
-    var buf = List<int>.filled(16, 0);
+    var buf = Uint8List(16);
     options = (options != null) ? options : {};
 
     var clockSeq =

--- a/lib/uuid_util.dart
+++ b/lib/uuid_util.dart
@@ -2,12 +2,15 @@ library uuid_util;
 
 import 'dart:math';
 
+import 'dart:typed_data';
+
 class UuidUtil {
   /// Math.Random()-based RNG. All platforms, fast, not cryptographically strong. Optional Seed passable.
-  static List<int> mathRNG({int seed = -1}) {
-    var b = List<int>(16);
+  static Uint8List mathRNG({int seed = -1}) {
+    var b = Uint8List(16);
 
     var rand = (seed == -1) ? Random() : Random(seed);
+
     for (var i = 0; i < 16; i++) {
       b[i] = rand.nextInt(256);
     }
@@ -18,8 +21,8 @@ class UuidUtil {
   }
 
   /// Crypto-Strong RNG. All platforms, unknown speed, cryptographically strong (theoretically)
-  static List<int> cryptoRNG() {
-    var b = List<int>(16);
+  static Uint8List cryptoRNG() {
+    var b = Uint8List(16);
     var rand = Random.secure();
     for (var i = 0; i < 16; i++) {
       b[i] = rand.nextInt(256);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: uuid
-version: 2.2.2
+version: 2.3.0-nullsafety.0
 description: >
   RFC4122 (v1, v4, v5) UUID Generator and Parser for all Dart platforms (Web, VM, Flutter)
 homepage: https://github.com/Daegalus/dart-uuid

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,10 +4,18 @@ description: >
   RFC4122 (v1, v4, v5) UUID Generator and Parser for all Dart platforms (Web, VM, Flutter)
 homepage: https://github.com/Daegalus/dart-uuid
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 dependencies:
-  crypto: ">=2.0.0 <3.0.0"
-  convert: ">=2.0.0 <3.0.0"
+  crypto: "^3.0.0-nullsafety"
+  convert: "^3.0.0-nullsafety"
 dev_dependencies:
   pedantic: ">=1.9.0"
-  test: any
+  test: ^1.16.0-nullsafety
+dependency_overrides:
+  crypto:
+    git:
+      url: https://github.com/dart-lang/crypto.git
+      ref: "3.0"
+  # test depends on shelf_static which requires convert <3.0.0, so temporarily
+  # add an override.
+  convert: ^3.0.0-nullsafety

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 import 'package:uuid/uuid_util.dart';
@@ -89,6 +91,16 @@ void main() {
         expect(code[19], isNot(equals('c')));
       }
     });
+
+    test('Using buffers', () {
+      var buffer = Uint8List(16);
+      var options = {'mSecs': TIME, 'nSecs': 0};
+
+      var wihoutBuffer = uuid.v1(options: options);
+      uuid.v1buffer(buffer, options: options);
+
+      expect(uuid.unparse(buffer), equals(wihoutBuffer));
+    });
   });
 
   group('[Version 4 Tests]', () {
@@ -99,6 +111,17 @@ void main() {
       });
       var u1 = '4dff2ea7-7bc8-4fea-8da0-a4993073bdb3';
       expect(u0, equals(u1));
+    });
+
+    test('Consistency check with buffer', () {
+      var buffer = Uint8List(16);
+      uuid.v4buffer(buffer, options: {
+        'rng': UuidUtil.mathRNG,
+        'namedArgs': Map.fromIterables([const Symbol('seed')], [1])
+      });
+
+      var u1 = '4dff2ea7-7bc8-4fea-8da0-a4993073bdb3';
+      expect(uuid.unparse(buffer), equals(u1));
     });
 
     test('Return same output as entered for "random" option', () {
@@ -167,6 +190,16 @@ void main() {
       var u1 = uuid.v5(null, 'www.google.com');
 
       expect(u0, isNot(equals(u1)));
+    });
+
+    test('Using buffers', () {
+      var buffer = Uint8List(16);
+      var wihoutBuffer =
+          uuid.v5(null, 'www.google.com', options: {'randomNamespace': false});
+      uuid.v5buffer(null, 'www.google.com', buffer,
+          options: {'randomNamespace': false});
+
+      expect(uuid.unparse(buffer), equals(wihoutBuffer));
     });
   });
 


### PR DESCRIPTION
The migration was relatively straightforward:

- The library used to allocate byte buffers with `List<int>(16)`, which is not allowed in null-safe Dart. We now use an `Uint8List` with bytes initialized to `0` which is also more efficient
- I made `_byteToHex` a static field since its only needed once. This allows us to initialize it right away to avoid nullability issues
- I added three tests to verify that the `vXbuffer`-methods work as intended
- I replaced usages of `_hexToByte` with `int.parse`: This simplifies code, and parsing an int is probably cheaper than looking up strings.

The migration guide recommends increasing the major version after migrating to null safety, but I didn't have to make any breaking changes to the package so I think  `2.3.0` should be fine.

Closes #50, but it probably has to wait until the `crypto` package is released and conflicts with `shelf_static` are resolved.