### PR TITLE
Remove git dependency override for crypto package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,15 +6,11 @@ homepage: https://github.com/Daegalus/dart-uuid
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
 dependencies:
-  crypto: "^3.0.0-nullsafety"
+  crypto: "^3.0.0-nullsafety.0"
 dev_dependencies:
   pedantic: ">=1.9.0"
-  test: ^1.16.0-nullsafety
+  test: ^1.16.0-nullsafety.13
 dependency_overrides:
-  crypto:
-    git:
-      url: https://github.com/dart-lang/crypto.git
-      ref: "master"
-  # test depends on shelf_static which requires convert <3.0.0, so temporarily
-  # add an override.
-  convert: ^3.0.0-nullsafety
+  # We're overriding crypto because test depends on web_socket_channel which
+  # doesn't support crypto 3.0 yet. That's only a dev dependency though.
+  crypto: ^3.0.0-nullsafety


### PR DESCRIPTION
The first null-safe version of the `crypto` package has been released to pub, so we can replace the git dependency on crypto with a regular dependency.

We still need a dependency override because `test` doesn't support `crypto: ^3.0.0-nullsafety` yet, but since the conflicts only come from test (a `dev_dependency`), it should be safe to publish the null-safe version now!