### PR TITLE
Uuidvalue input validation

### DIFF
--- a/lib/uuid.dart
+++ b/lib/uuid.dart
@@ -448,11 +448,11 @@ class UuidValue {
   ///
   /// Takes in a string representation of a [uuid] to wrap.
   ///
-  /// Optioanlly, you can disable the validation check in the constructor
-  /// by setting [validate] to `true`.
+  /// Optionally , you can disable the validation check in the constructor
+  /// by setting [validate] to `false`.
   UuidValue(this.uuid, [bool validate = true]) {
-    if (validate) {
-      Uuid.isValidUUID(uuid);
+    if (validate && !Uuid.isValidUUID(uuid)) {
+      throw FormatException('The provided UUID is invalid.', uuid);
     }
   }
 

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -259,7 +259,8 @@ void main() {
     test('Pass invalid Uuid to constructor', () {
       const INVALID_UUID = 'For sure not a valid UUID';
       expect(Uuid.isValidUUID(INVALID_UUID), false);
-      expect(UuidValue(INVALID_UUID, true), throwsException);
+      expect(
+          () => UuidValue(INVALID_UUID, true), throwsA(isA<FormatException>()));
 
       final uuidval = UuidValue(INVALID_UUID, false);
       expect(uuidval.uuid, INVALID_UUID);

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -247,4 +247,22 @@ void main() {
           throwsA(isA<FormatException>()));
     });
   });
+
+  group('[UuidValue]', () {
+    test('Construct UuidValue instance', () {
+      const VALID_UUID = '87cd4eb3-cb88-449b-a1da-e468fd829310';
+      expect(Uuid.isValidUUID(VALID_UUID), true);
+      final uuidval = UuidValue(VALID_UUID, true);
+      expect(uuidval.uuid, VALID_UUID);
+    });
+
+    test('Pass invalid Uuid to constructor', () {
+      const INVALID_UUID = 'For sure not a valid UUID';
+      expect(Uuid.isValidUUID(INVALID_UUID), false);
+      expect(UuidValue(INVALID_UUID, true), throwsException);
+
+      final uuidval = UuidValue(INVALID_UUID, false);
+      expect(uuidval.uuid, INVALID_UUID);
+    });
+  });
 }


### PR DESCRIPTION
Throw a `FormatException` when `Uuid.isValidUUID(uuid)` evaluates false when constructing a UuidValue instance.