### PR TITLE
added support and test for microsoft guid

### DIFF
--- a/lib/uuid.dart
+++ b/lib/uuid.dart
@@ -56,7 +56,7 @@ class Uuid {
 
     // Make sure if it passes the above, that its valid.
     const pattern =
-        r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$';
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$';
     final regex = RegExp(pattern, caseSensitive: false, multiLine: true);
     final match = regex.hasMatch(fromString);
     return match;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: uuid
-version: 3.0.3
+version: 3.0.4
 description: >
   RFC4122 (v1, v4, v5) UUID Generator and Parser for all Dart platforms (Web, VM, Flutter)
 homepage: https://github.com/Daegalus/dart-uuid

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -197,6 +197,13 @@ void main() {
 
       expect(numDuplicates, equals(0), reason: 'duplicate UUIDs generated');
     });
+
+    test('Check if V4 supports Microsoft Guid', () {
+      var guidString = '2400ee73-282c-4334-e153-08d8f922d1f9';
+
+      var isValid = Uuid.isValidUUID(fromString: guidString);
+      expect(isValid, true);
+    });
   });
 
   group('[Version 5 Tests]', () {

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -201,8 +201,16 @@ void main() {
     test('Check if V4 supports Microsoft Guid', () {
       var guidString = '2400ee73-282c-4334-e153-08d8f922d1f9';
 
-      var isValid = Uuid.isValidUUID(fromString: guidString);
-      expect(isValid, true);
+      var isValidDefault = Uuid.isValidUUID(fromString: guidString);
+      expect(isValidDefault, false);
+
+      var isValidRFC = Uuid.isValidUUID(
+          fromString: guidString, validationMode: ValidationMode.strictRFC4122);
+      expect(isValidRFC, false);
+
+      var isValidNonStrict = Uuid.isValidUUID(
+          fromString: guidString, validationMode: ValidationMode.nonStrict);
+      expect(isValidNonStrict, true);
     });
   });
 
@@ -271,6 +279,32 @@ void main() {
 
       final uuidval = UuidValue(INVALID_UUID, false);
       expect(uuidval.uuid, INVALID_UUID.toLowerCase());
+    });
+
+    test('Pass valid Guid to constructor without validation mode', () {
+      const VALID_GUID = '2400ee73-282c-4334-e153-08d8f922d1f9';
+      expect(Uuid.isValidUUID(fromString: VALID_GUID), false);
+      expect(
+          () => UuidValue(VALID_GUID, true),
+          throwsA(isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            'The provided UUID is not RFC4122. Probably you are using a Microsoft GUID. Try to set validationMode=nonStrict',
+          )));
+
+      final uuidval = UuidValue(VALID_GUID, false);
+      expect(uuidval.uuid, VALID_GUID.toLowerCase());
+    });
+
+    test('Pass valid Guid to constructor with validation mode nonStrict', () {
+      const VALID_GUID = '2400ee73-282c-4334-e153-08d8f922d1f9';
+      expect(
+          Uuid.isValidUUID(
+              fromString: VALID_GUID, validationMode: ValidationMode.nonStrict),
+          true);
+
+      final uuidval = UuidValue(VALID_GUID, true, ValidationMode.nonStrict);
+      expect(uuidval.uuid, VALID_GUID.toLowerCase());
     });
   });
 }


### PR DESCRIPTION
A microsoft guid i.e. 2400ee73-282c-4334-e153-08d8f922d1f9 wasn't matched by your isValidUUID regex pattern.

I think it makes sense, to be not stricter then really needed. Especially also I couldn't find the place in the RFC4122 where the first digit of the 'clock-seq-low' part of a uuid is limited, as it was by you regex pattern.  Probably there are many cases, where a rest api call and deserialization from json is made for uuid/guids from a Microsoft backend.

I hope that you're ok with this approach. Otherwise we also could implement a "strict" mode or v4guid or similar. But this makes the code unnecessarily complex. 
