### PR TITLE
[Fix] Modify the pattern in nonStrict mode.

### DIFF
--- a/lib/uuid.dart
+++ b/lib/uuid.dart
@@ -70,7 +70,7 @@ class Uuid {
       case ValidationMode.nonStrict:
         {
           const pattern =
-              r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$';
+              r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$';
           final regex = RegExp(pattern, caseSensitive: false, multiLine: true);
           final match = regex.hasMatch(fromString);
           return match;


### PR DESCRIPTION
Hello Daegalus,

Thank you so much for providing a great library, but I face a problem, that I got a uuid like this ('3d3e6f13-24c2-0ad6-3691-8d58fdb59b1c') and it couldn't pass the validation. I look back the code and find the validation that used before is not different. so I changed the pattern under non-Strict mode similar to before.

Thank you again!