### PR TITLE
Ensure constructor options are used correctly

### DIFF
--- a/lib/uuid.dart
+++ b/lib/uuid.dart
@@ -24,17 +24,19 @@ class Uuid {
   });
 
   final options;
-  final _state = {
-    'seedBytes': null,
-    'node': null,
-    'clockSeq': null,
-    'mSecs': 0,
-    'nSecs': 0,
-    'hasInitV1': false,
-    'hasInitV4': false
-  };
 
-  Uuid({Map<String, dynamic>? this.options});
+  static final _stateExpando = Expando<Map<String, dynamic>>();
+  Map<String, dynamic> get _state => _stateExpando[this] ??= {
+        'seedBytes': null,
+        'node': null,
+        'clockSeq': null,
+        'mSecs': 0,
+        'nSecs': 0,
+        'hasInitV1': false,
+        'hasInitV4': false
+      };
+
+  const Uuid({Map<String, dynamic>? this.options});
 
   /// Validates the provided [uuid] to make sure it has all the necessary
   /// components and formatting and returns a [bool]

--- a/lib/uuid.dart
+++ b/lib/uuid.dart
@@ -24,7 +24,7 @@ class Uuid {
   });
 
   final options;
-  static final _state = {
+  final _state = {
     'seedBytes': null,
     'node': null,
     'clockSeq': null,
@@ -34,7 +34,7 @@ class Uuid {
     'hasInitV4': false
   };
 
-  const Uuid({Map<String, dynamic>? this.options});
+  Uuid({Map<String, dynamic>? this.options});
 
   /// Validates the provided [uuid] to make sure it has all the necessary
   /// components and formatting and returns a [bool]
@@ -185,8 +185,8 @@ class Uuid {
         '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}';
   }
 
-  void _initV1(Map<String, dynamic>? options) {
-    options ??= const {};
+  void _initV1() {
+    final options = this.options ?? const {};
 
     if (!(_state['hasInitV1']! as bool)) {
       var v1PositionalArgs = (options['v1rngPositionalArgs'] != null)
@@ -224,16 +224,16 @@ class Uuid {
     }
   }
 
-  void _initV4(Map<String, dynamic>? options) {
-    options ??= {};
+  void _initV4() {
+    final options = this.options ?? const {};
 
     if (!(_state['hasInitV4']! as bool)) {
       // Set the globalRNG function to mathRNG with the option to set an alternative globally
-      var gPositionalArgs = (options['grngPositionalArgs'] != null)
-          ? options['grngPositionalArgs']
-          : [];
-      var gNamedArgs = (options['grngNamedArgs'] != null)
-          ? options['grngNamedArgs'] as Map<Symbol, dynamic>
+      var gPositionalArgs = (options['gPositionalArgs'] != null)
+          ? options['gPositionalArgs']
+          : const [];
+      var gNamedArgs = (options['gNamedArgs'] != null)
+          ? options['gNamedArgs'] as Map<Symbol, dynamic>
           : const <Symbol, dynamic>{};
 
       final grng = options['grng'];
@@ -259,7 +259,7 @@ class Uuid {
     var buf = Uint8List(16);
     options ??= {};
 
-    _initV1(options);
+    _initV1();
     var clockSeq = (options['clockSeq'] != null)
         ? options['clockSeq']
         : _state['clockSeq'] as int;
@@ -380,7 +380,7 @@ class Uuid {
   String v4({Map<String, dynamic>? options}) {
     options = (options != null) ? options : <String, dynamic>{};
 
-    _initV4(options);
+    _initV4();
     // Use the built-in RNG or a custom provided RNG
     var positionalArgs =
         (options['positionalArgs'] != null) ? options['positionalArgs'] : [];


### PR DESCRIPTION
Fixes #75 

I also added some tests to ensure it now behaves correctly. I found the following bugs, which are now fixed:
- global options are simply not used
- global v4 options used wrong keys for positional and named arguments
- global state was static, not a per instance member
  - I decided to use an `Expando` for this, to keep backwards compability
  - ~for this to be fixed I had to remove the `const` from the constructor. I am aware, that this is a potentially breaking change, but it is the "clean" way of doing this. If you prefer to do this without a breaking change, there is a way around that using the `Expando`. Just tell me which one you prefer.~