### PR TITLE
Fixed parse to allow buffers larger than 16 bytes to be used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v3.0.7
+
+* Fixed parse to allow buffers larger than 16 bytes to be used.
+
 v3.0.6
 
 * Enable `avoid_dynamic_calls` linting and fix appropriately. (Thanks @devoncarew)

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -261,6 +261,44 @@ void main() {
       expect(() => Uuid.unparse(Uuid.parse('(this is the uuid -> $id$id')),
           throwsA(isA<FormatException>()));
     });
+
+    group('buffer:', () {
+      const size = 64;
+      final buffer = Uint8List(size);
+
+      group('offset good:', () {
+        for (final testCase in {
+          'offset=0': 0,
+          'offset=1': 1,
+          'offset in the middle': 32,
+          'offset 16 bytes before the end': size - 16,
+        }.entries) {
+          test(testCase.key, () {
+            final v = Uuid.parse(Uuid.NAMESPACE_OID,
+                buffer: buffer, offset: testCase.value);
+
+            expect(Uuid.unparse(v, offset: testCase.value),
+                equals(Uuid.NAMESPACE_OID));
+          });
+        }
+      });
+
+      group('offset bad:', () {
+        for (final testCase in {
+          'offset 15 bytes before end': size - 15,
+          'offset at end of buffer': size,
+          'offset after end of buffer': size + 1,
+          'offset is negative': -1
+        }.entries) {
+          test(testCase.key, () {
+            expect(
+                () => Uuid.parse(Uuid.NAMESPACE_OID,
+                    buffer: buffer, offset: testCase.value),
+                throwsA(isA<RangeError>()));
+          });
+        }
+      });
+    });
   });
 
   group('[UuidValue]', () {


### PR DESCRIPTION
Fixed `parse` method to allow _buffer_ and _offset_ parameters to be used as intended.

Previously, the code said `if (buffer.length != 16) throw ...` which means larger buffers cannot be passed in, and the only valid value for _offset_ is zero.

This code change allows for any buffer size as long as the number of bytes between the _offset_ and the end of the buffer is 16 bytes or greater.