### PR TITLE
Provide constants for RFC4122 namespaces in UuidValue

### DIFF
--- a/lib/uuid_value.dart
+++ b/lib/uuid_value.dart
@@ -31,8 +31,14 @@ class UuidValue {
   factory UuidValue.fromList(List<int> byteList, {int? offset}) {
     return UuidValue(UuidParsing.unparse(byteList, offset: offset ?? 0));
   }
+  
+  static const dns = UuidValue._(Uuid.NAMESPACE_DNS);
+  static const url = UuidValue._(Uuid.NAMESPACE_URL);
+  static const oid = UuidValue._(Uuid.NAMESPACE_OID);
+  static const x500 = UuidValue._(Uuid.NAMESPACE_X500);
+  static const nil = UuidValue._(Uuid.NAMESPACE_NIL);
 
-  UuidValue._(this.uuid);
+  const UuidValue._(this.uuid);
 
   // toBytes() converts the internal string representation to a list of bytes.
   Uint8List toBytes() {


### PR DESCRIPTION
This way developers can use `const` constructors where no values are immediately available.
Ex.
```
class Person {
  final UuidValue id;
  final String name;
  final int age;

  const Person({
    required this.id,
    required this.name,
    required this.age,
  });

  static const empty = Person(
    id: UuidValue.nil,
    name: '',
    age: 0,
  );
}
```
I'm sure there are many other instances where this would be useful as well.