### PR TITLE
Fix #89 v7: Uint64List not supported by dart2js. and v6: Uint64 accessor not supported by dart2js.

### DIFF
--- a/lib/v6.dart
+++ b/lib/v6.dart
@@ -43,33 +43,34 @@ class UuidV6 {
   /// options detailed in the readme.
   ///
   /// https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format#section-4.3
-  String generate({V6Options? options}) {
-    _init();
+  String generate({Map<String, dynamic>? options}) {
     var buf = Uint8List(16);
+    var buf32 = Uint8List(16);
+    options ??= const {};
 
-    int clockSeq = options?.clockSeq ?? V6State.clockSeq ?? 0;
+    int clockSeq = options['clockSeq'] ?? this.clockSeq;
 
     // UUID timestamps are 100 nano-second units since the Gregorian epoch,
     // (1582-10-15 00:00). Time is handled internally as 'msecs' (integer
     // milliseconds) and 'nsecs' (100-nanoseconds offset from msecs) since unix
     // epoch, 1970-01-01 00:00.
-    int mSecs = options?.mSecs ?? (DateTime.now()).millisecondsSinceEpoch;
+    int mSecs = options['mSecs'] ?? (DateTime.now()).millisecondsSinceEpoch;
 
     // Per 4.2.1.2, use count of uuid's generated during the current clock
     // cycle to simulate higher resolution clock
-    int nSecs = options?.nSecs ?? V6State.nSecs + 1;
+    int nSecs = options['nSecs'] ?? this.nSecs + 1;
 
     // Time since last uuid creation (in msecs)
-    var dt = (mSecs - V6State.mSecs) + (nSecs - V6State.nSecs) / 10000;
+    var dt = (mSecs - this.mSecs) + (nSecs - this.nSecs) / 10000;
 
     // Per 4.2.1.2, Bump clockseq on clock regression
-    if (dt < 0 && options?.clockSeq == null) {
+    if (dt < 0 && options['clockSeq'] == null) {
       clockSeq = clockSeq + 1 & 0x3fff;
     }
 
     // Reset nsecs if clock regresses (new clockseq) or we've moved onto a new
     // time interval
-    if ((dt < 0 || mSecs > V6State.mSecs) && options?.nSecs == null) {
+    if ((dt < 0 || mSecs > this.mSecs) && options['nSecs'] == null) {
       nSecs = 0;
     }
 
@@ -78,25 +79,28 @@ class UuidV6 {
       throw Exception('uuid.v6(): Can\'t create more than 10M uuids/sec');
     }
 
-    V6State.mSecs = mSecs;
-    V6State.nSecs = nSecs;
-    V6State.clockSeq = clockSeq;
+    this.mSecs = mSecs;
+    this.nSecs = nSecs;
+    this.clockSeq = clockSeq;
 
     // Per 4.1.4 - Convert from unix epoch to Gregorian epoch
     mSecs += 12219292800000;
 
     var uuidTime = mSecs * 10000 + nSecs;
 
-    var high = uuidTime << 4;
+    var high32a = uuidTime >> 28;
+    var high32b = uuidTime << 4;
     var low = uuidTime & 0x0fff | 0x6000;
     var clock = (clockSeq & 0x3fff) | 0x8000;
-    buf..buffer.asByteData().setUint64(0, high);
+
+    buf..buffer.asByteData().setUint32(0, high32a);
+    buf..buffer.asByteData().setUint32(4, high32b);
     buf..buffer.asByteData().setUint16(6, low);
     buf..buffer.asByteData().setUint16(8, clock);
 
-    var node =
-        options?.node ?? V6State.nodeId ?? [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    var node = (options['node'] != null) ? options['node'] : nodeId;
     buf.setAll(10, node);
+    buf32.setAll(10, node);
 
     return UuidParsing.unparse(buf);
   }

--- a/lib/v7.dart
+++ b/lib/v7.dart
@@ -18,18 +18,12 @@ class UuidV7 {
   /// options detailed in the readme.
   ///
   /// https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format#section-4.3
-  String generate({Map<String, dynamic>? options}) {
+  String generate({V7Options? options}) {
     var buf = Uint8List(16);
-    options ??= const {};
-
-    int time =
-        options['time'] ?? (DateTime.now().toUtc()).millisecondsSinceEpoch;
-
-    this.time = time;
+    int time = options?.time ?? (DateTime.now().toUtc()).millisecondsSinceEpoch;
 
     var timeList32 = Uint8List(8)..buffer.asUint32List()[0] = time >> 16;
     var timeList16 = Uint8List(8)..buffer.asUint16List()[0] = time;
-
     var endIndex32 = timeList32.length - 1;
     var endIndex16 = timeList16.length - 1;
 
@@ -45,9 +39,7 @@ class UuidV7 {
 
     buf.setAll(0, timeList32.reversed);
     buf.setAll(4, timeList16.reversed);
-    var randomBytes = (options['randomBytes'] != null)
-        ? (options['randomBytes'] as List<int>)
-        : randomData();
+    List<int> randomBytes = options?.randomBytes ?? _randomData();
 
     buf.setRange(6, 16, randomBytes);
     buf.setRange(6, 7, [buf.getRange(6, 7).last & 0x0f | 0x70]);


### PR DESCRIPTION
Fixes #89 

Flutter Web throws `Uint64List not supported by dart2js.` for UUIDv7 and `Uint64 accessor not supported by dart2js.` for UUIDv6 when trying to generate them, respectively.

This seems to be related to the following issues:
1. https://github.com/dart-lang/sdk/issues/10275
2. https://github.com/dart-lang/sdk/issues/50332

I found a workaround using `Uint32List` and adjusted the bits. Not sure if this is the optimal solution.