### PR TITLE
toBytes no longer validates

### DIFF
--- a/lib/uuid.dart
+++ b/lib/uuid.dart
@@ -159,7 +159,7 @@ class Uuid {
   /// ```
   String v1(
       {@Deprecated('use config instead. Removal in 5.0.0')
-          Map<String, dynamic>? options,
+      Map<String, dynamic>? options,
       V1Options? config}) {
     if (options != null && options.isNotEmpty) {
       config = V1Options(options["clockSeq"], options["mSecs"],
@@ -199,7 +199,7 @@ class Uuid {
   List<int> v1buffer(
     List<int> buffer, {
     @Deprecated('use config instead. Removal in 5.0.0')
-        Map<String, dynamic>? options,
+    Map<String, dynamic>? options,
     V1Options? config,
     int offset = 0,
   }) {
@@ -234,7 +234,7 @@ class Uuid {
   /// ```
   UuidValue v1obj(
       {@Deprecated('use config instead. Removal in 5.0.0')
-          Map<String, dynamic>? options,
+      Map<String, dynamic>? options,
       V1Options? config}) {
     return config != null
         ? UuidValue(v1(config: config))
@@ -299,7 +299,7 @@ class Uuid {
   /// ```
   String v4(
       {@Deprecated('use config instead. Removal in 5.0.0')
-          Map<String, dynamic>? options,
+      Map<String, dynamic>? options,
       V4Options? config}) {
     if (options != null && options.isNotEmpty) {
       var rng = options["rng"];
@@ -338,7 +338,7 @@ class Uuid {
   List<int> v4buffer(
     List<int> buffer, {
     @Deprecated('use config instead. Removal in 5.0.0')
-        Map<String, dynamic>? options,
+    Map<String, dynamic>? options,
     V4Options? config,
     int offset = 0,
   }) {
@@ -374,7 +374,7 @@ class Uuid {
   /// ```
   UuidValue v4obj(
       {@Deprecated('use config instead. Removal in 5.0.0')
-          Map<String, dynamic>? options,
+      Map<String, dynamic>? options,
       V4Options? config}) {
     return config != null
         ? UuidValue(v4(config: config))
@@ -400,11 +400,9 @@ class Uuid {
   /// uuid.v5(Uuid.NAMESPACE_URL, 'www.google.com');
   /// // -> "c74a196f-f19d-5ea9-bffd-a2742432fc9c"
   /// ```
-  String v5(
-      String? namespace,
-      String? name,
+  String v5(String? namespace, String? name,
       {@Deprecated('use config instead. Removal in 5.0.0')
-          Map<String, dynamic>? options,
+      Map<String, dynamic>? options,
       V5Options? config}) {
     if (options != null && options.isNotEmpty) {
       V4Options? v4config;
@@ -441,7 +439,7 @@ class Uuid {
     String? name,
     List<int>? buffer, {
     @Deprecated('use config instead. Removal in 5.0.0')
-        Map<String, dynamic>? options,
+    Map<String, dynamic>? options,
     V5Options? config,
     int offset = 0,
   }) {
@@ -472,11 +470,9 @@ class Uuid {
   /// print(uuidValue) -> // -> 'c74a196f-f19d-5ea9-bffd-a2742432fc9c'
   /// uuidValue.toBytes() -> // -> [...]
   /// ```
-  UuidValue v5obj(
-      String? namespace,
-      String? name,
+  UuidValue v5obj(String? namespace, String? name,
       {@Deprecated('use config instead. Removal in 5.0.0')
-          Map<String, dynamic>? options,
+      Map<String, dynamic>? options,
       V5Options? config}) {
     return config != null
         ? UuidValue(v5(namespace, name, config: config))

--- a/lib/uuid_value.dart
+++ b/lib/uuid_value.dart
@@ -50,8 +50,8 @@ class UuidValue {
   }
 
   // toBytes() converts the internal string representation to a list of bytes.
-  Uint8List toBytes() {
-    return UuidParsing.parseAsByteList(uuid, validate: false);
+  Uint8List toBytes({bool validate = false}) {
+    return UuidParsing.parseAsByteList(uuid, validate: validate);
   }
 
   // toString() returns the String representation of the UUID

--- a/lib/uuid_value.dart
+++ b/lib/uuid_value.dart
@@ -8,15 +8,15 @@ class UuidValue {
   final String uuid;
 
   /// fromByteList() creates a UuidValue from a [Uint8List] of bytes.
-  factory UuidValue.fromByteList(Uint8List byteList, {int? offset}) {
-    return UuidValue(UuidParsing.unparse(byteList, offset: offset ?? 0));
+  factory UuidValue.fromByteList(Uint8List byteList, {int? offset, bool validate = true, ValidationMode validationMode = ValidationMode.strictRFC4122}) {
+    return UuidValue(UuidParsing.unparse(byteList, offset: offset ?? 0), validate, validationMode);
   }
 
   /// fromList() creates a UuidValue from a [List<int>] of bytes.
-  factory UuidValue.fromList(List<int> byteList, {int? offset}) {
-    return UuidValue(UuidParsing.unparse(byteList, offset: offset ?? 0));
+  factory UuidValue.fromList(List<int> byteList, {int? offset, bool validate = true, ValidationMode validationMode = ValidationMode.strictRFC4122}) {
+    return UuidValue(UuidParsing.unparse(byteList, offset: offset ?? 0), validate, validationMode);
   }
-
+  
   /// withValidation() creates a UuidValue from a [uuid] string.
   /// Optionally, you can provide a [validationMode] to use when validating
   /// the uuid string.

--- a/lib/uuid_value.dart
+++ b/lib/uuid_value.dart
@@ -8,15 +8,15 @@ class UuidValue {
   final String uuid;
 
   /// fromByteList() creates a UuidValue from a [Uint8List] of bytes.
-  factory UuidValue.fromByteList(Uint8List byteList, {int? offset, bool validate = true, ValidationMode validationMode = ValidationMode.strictRFC4122}) {
-    return UuidValue(UuidParsing.unparse(byteList, offset: offset ?? 0), validate, validationMode);
+  factory UuidValue.fromByteList(Uint8List byteList, {int? offset}) {
+    return UuidValue(UuidParsing.unparse(byteList, offset: offset ?? 0));
   }
 
   /// fromList() creates a UuidValue from a [List<int>] of bytes.
-  factory UuidValue.fromList(List<int> byteList, {int? offset, bool validate = true, ValidationMode validationMode = ValidationMode.strictRFC4122}) {
-    return UuidValue(UuidParsing.unparse(byteList, offset: offset ?? 0), validate, validationMode);
+  factory UuidValue.fromList(List<int> byteList, {int? offset}) {
+    return UuidValue(UuidParsing.unparse(byteList, offset: offset ?? 0));
   }
-  
+
   /// withValidation() creates a UuidValue from a [uuid] string.
   /// Optionally, you can provide a [validationMode] to use when validating
   /// the uuid string.

--- a/lib/uuid_value.dart
+++ b/lib/uuid_value.dart
@@ -51,7 +51,7 @@ class UuidValue {
 
   // toBytes() converts the internal string representation to a list of bytes.
   Uint8List toBytes() {
-    return UuidParsing.parseAsByteList(uuid);
+    return UuidParsing.parseAsByteList(uuid, validate: false);
   }
 
   // toString() returns the String representation of the UUID


### PR DESCRIPTION
If you already have a UuidValue, `toBytes` should succeed if at all possible.

I ran into a case where I got a bluetooth service uuid that didn't validate for whatever reason, so when I went to serialize it back to disk it failed to serialize.  Turning off validation fixed it.