### PR TITLE
Faster CryptoRNG

### DIFF
--- a/lib/rng.dart
+++ b/lib/rng.dart
@@ -52,8 +52,12 @@ class CryptoRNG extends RNG {
   Uint8List generateInternal() {
     final b = Uint8List(16);
 
-    for (var i = 0; i < 16; i++) {
-      b[i] = _secureRandom.nextInt(256);
+    for (var i = 0; i < 16; i += 4) {
+      var k = _secureRandom.nextInt(1 << 32);
+      b[i] = k;
+      b[i + 1] = k >> 8;
+      b[i + 2] = k >> 16;
+      b[i + 3] = k >> 24;
     }
 
     return b;


### PR DESCRIPTION
Dart's `Random.secure` is _slow_. For example, every call to `nextInt()` opens a new handle to `/dev/urandom` on Android and Linux, and there is no API to get N random bytes.

A simple workaround here is to use `nextInt()` to request 4 bytes at a time instead of 1 (this is the maximum allowed). It's not great yet, but in my tests I can generate around twice as many V4 UUIDs per second with this change.
