### PR TITLE
🐛  fixes dependency issue for flutter 3.13.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+v4.4.3
+
+* Updated meta dependency to `meta: ">=1.0.5"` to support all possible versions of flutter.
+
+
 v4.4.2
 
 * Revert meta depenency version upgrade, was breaking flutter_test. (thanks @techouse)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Features:
 
 ```yaml
 dependencies:
-  uuid: ^4.4.2
+  uuid: ^4.4.3
 ```
 
 ```dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: uuid
-version: 4.4.2
+version: 4.4.3
 description: >
   RFC4122 (v1, v4, v5, v6, v7, v8) UUID Generator and Parser for Dart
 documentation: https://daegalus.github.io/dart-uuid/index.html
@@ -9,7 +9,7 @@ environment:
 dependencies:
   crypto: ^3.0.0
   sprintf: ^7.0.0
-  meta: ^1.10.0
+  meta: ">=1.0.5"
   fixnum: ^1.1.0
 dev_dependencies:
   lints: ^4.0.0


### PR DESCRIPTION
Fixes issue #123 

I've updated meta dependency to ` meta: ">=1.0.5"`. So, it should now work with all the projects that uses meta version `>= 1.0.5 & <= latest`. The reason for setting the minimum version to 1.0.5 was because the `@experimental` annotation was introduced in this version which is used in this package.