### PR TITLE
Always use `CryptoRNG` as the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Features:
 * Supports RFC9562 version 6, version 7, and version 8
 * Runs in web, server, and flutter
 * Cryptographically strong random number generation on all platforms
-  * **Defaults to non-crypto generator, see UuidUtil for cryptoRNG**
 * [Documentation](https://daegalus.github.io/dart-uuid/index.html)
 
 ## Getting Started

--- a/lib/data.dart
+++ b/lib/data.dart
@@ -1,7 +1,7 @@
 import 'package:uuid/rng.dart';
 
 /// [GlobalOptions] stores the global options passed into the library on instantiation.
-/// [GlobalOptions.rng] is the random number generator class to use. Defaults to MathRNG() [MathRNG]
+/// [GlobalOptions.rng] is the random number generator class to use. Defaults to CryptoRNG() [CryptoRNG]
 class GlobalOptions {
   final RNG? rng;
 
@@ -32,7 +32,7 @@ class V1Options {
 /// [V4Options] stores the options passed into the v4 function.
 /// [random] is the random bytes to use to generate the UUID. Primarily used for
 /// testing, or recreating a UUID
-/// [rng] is the random number generator function to use. Defaults to MathRNG() [MathRNG]
+/// [rng] is the random number generator function to use. Defaults to CryptoRNG() [CryptoRNG]
 class V4Options {
   final List<int>? random;
   final RNG? rng;
@@ -116,7 +116,7 @@ class V1State {
   static int? clockSeq = 0;
   static int mSecs = 0;
   static int nSecs = 0;
-  static RNG random = MathRNG();
+  static RNG random = CryptoRNG();
   static bool initialized = false;
 }
 
@@ -126,7 +126,7 @@ class V1State {
 /// initialized once already. Prevents re-initialization on subsequent calls to
 /// _init() from within the v4 function.
 class V4State {
-  static RNG random = MathRNG();
+  static RNG random = CryptoRNG();
   static bool initialized = true;
 }
 
@@ -143,7 +143,7 @@ class V6State {
   static int? clockSeq;
   static int mSecs = 0;
   static int nSecs = 0;
-  static RNG random = MathRNG();
+  static RNG random = CryptoRNG();
   static bool initialized = false;
 }
 
@@ -153,7 +153,7 @@ class V6State {
 /// initialized once already. Prevents re-initialization on subsequent calls to
 /// _init() from within the v4 function.
 class V7State {
-  static RNG random = MathRNG();
+  static RNG random = CryptoRNG();
   static bool initialized = true;
 }
 
@@ -163,6 +163,6 @@ class V7State {
 /// initialized once already. Prevents re-initialization on subsequent calls to
 /// _init() from within the v4 function.
 class V8State {
-  static RNG random = MathRNG();
+  static RNG random = CryptoRNG();
   static bool initialized = true;
 }

--- a/lib/uuid.dart
+++ b/lib/uuid.dart
@@ -48,13 +48,13 @@ class Uuid {
   /// for all UUID generation.
   /// [GlobalOptions.rng] is a [RNG] class that returns a list of random bytes.
   ///
-  /// Defaults rng function is `UuidUtil.mathRNG`
+  /// Defaults rng function is `UuidUtil.cryptoRNG`
   ///
-  /// Example: Using CryptoRNG globally
+  /// Example: Using MathRNG globally
   ///
   /// ```dart
   /// var uuid = Uuid(options: {
-  ///   'grng': UuidUtil.cryptoRNG
+  ///   'grng': UuidUtil.mathRNG
   /// })
   ///
   /// // Generate a v4 (random) id that will use cryptRNG for its rng function
@@ -244,7 +244,7 @@ class Uuid {
 
   /// Generates a RNG version 4 UUID
   ///
-  /// By default it will generate a string based mathRNG, and will return
+  /// By default it will generate a string based cryptoRNG, and will return
   /// a string. If you wish to use crypto-strong RNG, pass in UuidUtil.cryptoRNG
   ///
   /// The first argument is an options map that takes various configuration
@@ -315,7 +315,7 @@ class Uuid {
 
   /// Generates a RNG version 4 UUID into a provided buffer
   ///
-  /// By default it will generate a string based off mathRNG, and will
+  /// By default it will generate a string based off cryptoRNG, and will
   /// place the result into the provided [buffer]. The [buffer] will also be returned.
   /// If you wish to have crypto-strong RNG, pass in UuidUtil.cryptoRNG.
   ///
@@ -349,7 +349,7 @@ class Uuid {
 
   /// Generates a RNG version 4 UUID as a [UuidValue] object
   ///
-  /// By default it will generate a string based mathRNG, and will return
+  /// By default it will generate a string based cryptoRNG, and will return
   /// a [UuidValue] object. If you wish to use crypto-strong RNG, pass in UuidUtil.cryptoRNG
   ///
   /// The first argument is an options map that takes various configuration

--- a/lib/v4.dart
+++ b/lib/v4.dart
@@ -8,7 +8,7 @@ class UuidV4 {
 
   /// v4() Generates a RNG version 4 UUID
   ///
-  /// By default it will generate a string based mathRNG, and will return
+  /// By default it will generate a string based cryptoRNG, and will return
   /// a string. If you wish to use crypto-strong RNG, pass in UuidUtil.cryptoRNG
   ///
   /// The first argument is an options map that takes various configuration


### PR DESCRIPTION
Fixes https://github.com/daegalus/dart-uuid/issues/125

As mentioned [here](https://github.com/dart-lang/sdk/issues/56609#issuecomment-2321281919)

> Just want to add here that you should never generate UUID using default Random() generator. Use Random.secure() for that. Reason being that the amount of unique seeds for Random() are limited to 32 bits.

> So if you have lot of clients running, it is actually not that impossible to get two clients running with same seed just by accident.

The default RNG implementation should be `Random.secure()` not the plain `Random()`