### PR TITLE
Remove `sprintf` dependency

### DIFF
--- a/lib/v8.dart
+++ b/lib/v8.dart
@@ -41,11 +41,11 @@ class UuidV8 {
     var buf = Uint8List(16);
     DateTime time = options?.time ?? DateTime.timestamp();
 
-    buf.setRange(0, 2, UuidParsing.parseHexToBytes(_toHexlike(time.year, 4)));
-    buf.setRange(2, 3, UuidParsing.parseHexToBytes(_toHexlike(time.month, 2)));
-    buf.setRange(3, 4, UuidParsing.parseHexToBytes(_toHexlike(time.day, 2)));
-    buf.setRange(4, 5, UuidParsing.parseHexToBytes(_toHexlike(time.hour, 2)));
-    buf.setRange(5, 6, UuidParsing.parseHexToBytes(_toHexlike(time.minute, 2)));
+    buf.setRange(0, 2, UuidParsing.parseHexToBytes(_padLeft(time.year, 4)));
+    buf.setRange(2, 3, UuidParsing.parseHexToBytes(_padLeft(time.month, 2)));
+    buf.setRange(3, 4, UuidParsing.parseHexToBytes(_padLeft(time.day, 2)));
+    buf.setRange(4, 5, UuidParsing.parseHexToBytes(_padLeft(time.hour, 2)));
+    buf.setRange(5, 6, UuidParsing.parseHexToBytes(_padLeft(time.minute, 2)));
 
     var randomBytes = options?.randomBytes ??
         (goptions?.rng?.generate() ?? V8State.random.generate());
@@ -54,9 +54,9 @@ class UuidV8 {
     buf.setRange(6, 7, [buf.getRange(6, 7).last & 0x0f | 0x80]);
     buf.setRange(8, 9, [buf.getRange(8, 9).last & 0x3f | 0x80]);
 
-    buf.setRange(7, 8, UuidParsing.parseHexToBytes(_toHexlike(time.second, 2)));
+    buf.setRange(7, 8, UuidParsing.parseHexToBytes(_padLeft(time.second, 2)));
     var milliBytes = UuidParsing.parseHexToBytes(
-      _toHexlike(time.millisecond, 4),
+      _padLeft(time.millisecond, 4),
     );
     milliBytes[0] = milliBytes[0] & 0x0f | buf.getRange(8, 9).last & 0xf0;
     buf.setRange(8, 10, milliBytes);
@@ -64,8 +64,6 @@ class UuidV8 {
     return UuidParsing.unparse(buf);
   }
 
-  // Custom hex(like) converting function which converts '2024' into '0x2024'
-  // and '3' into '0x03' depending on amount of padding.
-  static String _toHexlike(int value, int padding) =>
-      '0x${value.toString().padLeft(padding, '0')}';
+  static String _padLeft(int value, int padding) =>
+      value.toString().padLeft(padding, '0');
 }

--- a/lib/validation.dart
+++ b/lib/validation.dart
@@ -50,10 +50,6 @@ class UuidValidation {
           final match = regex.hasMatch(fromString.toLowerCase());
           return match;
         }
-      default:
-        {
-          throw Exception('`$validationMode` is an invalid ValidationMode.');
-        }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
   crypto: ^3.0.0
-  sprintf: ^7.0.0
   meta: ^1.10.0
   fixnum: ^1.1.0
 dev_dependencies:


### PR DESCRIPTION
Going though dependencies, it looks like the `sprintf` dependency are not really justified based on the functionality being used of this package. I therefore suggest removing the package as dependency to reduce the amount of maintenance burden of dart-uuid.

I am not entirely sure why this hex converting logic are made like it is since it does not really generate "real" hex values since `2024` are converted to `0x2024` and not `0x07E8` which would be the correct value when converting `2024´ into hex.

To prevent failing tests and potential breaking changes, my implementation will still generate the exact same hex-like values as before the `sprintf` removal. But if we are open for changing this design, I can easily change the logic so we generate the needed `Uint8List` lists directly from the `int` values instead of going though this hex conversions.