### PR TITLE
fix: Remove the `experimental` annotation from the `UuidValue` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 **Version 4.x.x is a complete redesign of the underlying setup, but tries to be API compatible or similar to 3.x.**
 
-**UuidValue is still Experimental and the API for it is in flux, please pay attention to changelogs and versions.**
-
 [![Build Status](https://github.com/Daegalus/dart-uuid/workflows/Dart/badge.svg?branch=main&event=push)](https://github.com/Daegalus/dart-uuid/actions)
 
 Simple, fast generation of [RFC4122](https://www.ietf.org/rfc/rfc4122.txt) and [RFC9562](https://www.rfc-editor.org/rfc/rfc9562.html) UUIDs.

--- a/lib/uuid_value.dart
+++ b/lib/uuid_value.dart
@@ -1,13 +1,11 @@
 import 'dart:typed_data';
 
-import 'package:meta/meta.dart';
 import 'package:uuid/constants.dart';
 
 import 'parsing.dart';
 import 'uuid.dart';
 import 'validation.dart';
 
-@experimental
 class UuidValue {
   final String uuid;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
   crypto: ^3.0.0
-  meta: ^1.10.0
   fixnum: ^1.1.0
 dev_dependencies:
   lints: ^6.0.0


### PR DESCRIPTION
## Summary

Fixes: #140

## Changes

- Remove the `experimental` annotation from the `UuidValue` class.
- Remove the `meta` dependency, since it was only used for this annotation.
- Remove the disclaimer of the `UuidValue` being experimental from the README. 

## Motivation

As seen on the issue, the `experimental` annotation became a problem for using this package with the new analyzer rules enforced on Dart 3.11 and will make the package unusable for the community if not removed - since the class is no longer really experimental.

@daegalus If you have any consideration, it will be a pleasure to discuss. Otherwise, it would be great if we could have this in as soon as possible to fix the `pana` score on all community packages that depend on this one.