### PR TITLE
Add support for loose validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 Unreleased
-* Add support for loose validation
+* Add validators for uuid format (`Uuid.isValidUUIDFormat(...)`, `UuidValue.validateFormat()`, `UuidValidation.isValidUUIDFormat(...)` and `UuidValidation.isValidFormatOrThrow(...)`)
+* Add `UuidValue.withFormatValidation(...)` constructor
+* Add `Uuid.parseHex128(...)`, `Uuid.parseHex128AsByteList(...)`, `UuidParsing.parseHex128(...)` and `UuidParsing.parseHex128AsByteList(...)` methods
 
 v4.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+Unreleased
+* Add support for loose validation
+
 v4.5.3
 
 * Remove experimental flag on UUIDValue and remote meta dependency. (thanks @marcelomendoncasoares)

--- a/lib/enums.dart
+++ b/lib/enums.dart
@@ -8,8 +8,7 @@ enum ValidationMode {
   nonStrict,
   @Deprecated('Use strictRFC9562 instead.')
   strictRFC4122,
-  strictRFC9562,
-  loose
+  strictRFC9562
 }
 
 /// RFC4122 & RFC9562 provided namespaces for v3, v5, and v8 namespace based UUIDs

--- a/lib/enums.dart
+++ b/lib/enums.dart
@@ -8,7 +8,8 @@ enum ValidationMode {
   nonStrict,
   @Deprecated('Use strictRFC9562 instead.')
   strictRFC4122,
-  strictRFC9562
+  strictRFC9562,
+  loose
 }
 
 /// RFC4122 & RFC9562 provided namespaces for v3, v5, and v8 namespace based UUIDs

--- a/lib/parsing.dart
+++ b/lib/parsing.dart
@@ -50,6 +50,104 @@ class UuidParsing {
       UuidValidation.isValidOrThrow(
           fromString: uuid, validationMode: validationMode, noDashes: noDashes);
     }
+
+    return _parse(uuid, buffer, offset);
+  }
+
+  ///Parses the provided [uuid] into a list of byte values as a Uint8List.
+  /// Can optionally be provided a [buffer] to write into and
+  ///  a positional [offset] for where to start inputting into the buffer.
+  /// Throws FormatException if the UUID is invalid. Optionally you can set
+  /// [validate] to false to disable validation of the UUID before parsing.
+  static Uint8List parseAsByteList(String uuid,
+      {List<int>? buffer,
+      int offset = 0,
+      bool validate = true,
+      ValidationMode validationMode = ValidationMode.strictRFC9562,
+      bool noDashes = false}) {
+    return Uint8List.fromList(parse(uuid,
+        buffer: buffer,
+        offset: offset,
+        validate: validate,
+        validationMode: validationMode,
+        noDashes: noDashes));
+  }
+
+  /// Parses the provided [uuid] into a list of byte values as a List&lt;int&gt;.
+  /// Can optionally be provided a [buffer] to write into and
+  /// a positional [offset] for where to start inputting into the buffer.
+  ///
+  /// Returns the [buffer] containing the bytes. If no [buffer] was provided,
+  /// a new [buffer] is created and returned. If a [buffer] was provided, it
+  /// is returned (even if the uuid bytes are not placed at the beginning of
+  /// that [buffer]).
+  ///
+  /// Throws FormatException if the UUID format is invalid.
+  /// No validation is performed on the content of the uuid.
+  /// Optionally you can set [validate] to false to disable
+  /// validation of the UUID before parsing.
+  ///
+  /// Throws [RangeError] if a [buffer] is provided and it is too small.
+  /// It is also thrown if a non-zero [offset] is provided without providing
+  /// a [buffer].
+  static List<int> parseHex128(String uuid,
+      {List<int>? buffer,
+      int offset = 0,
+      bool validate = true,
+      bool noDashes = false}) {
+    if (validate) {
+      UuidValidation.isValidFormatOrThrow(
+          fromString: uuid, noDashes: noDashes);
+    }
+
+    return _parse(uuid, buffer, offset);
+  }
+
+  ///Parses the provided [uuid] into a list of byte values as a Uint8List.
+  /// Can optionally be provided a [buffer] to write into and
+  ///  a positional [offset] for where to start inputting into the buffer.
+  /// Throws FormatException if the UUID format is invalid.
+  /// No validation is performed on the content of the uuid.
+  /// Optionally you can set [validate] to false to disable
+  /// validation of the UUID before parsing.
+  static Uint8List parseHex128AsByteList(String uuid,
+      {List<int>? buffer,
+      int offset = 0,
+      bool validate = true,
+      bool noDashes = false}) {
+    return Uint8List.fromList(parseHex128(uuid,
+        buffer: buffer,
+        offset: offset,
+        validate: validate,
+        noDashes: noDashes));
+  }
+
+  /// Unparses a [buffer] of bytes and outputs a proper UUID string.
+  /// An optional [offset] is allowed if you want to start at a different point
+  /// in the buffer.
+  ///
+  /// Throws a [RangeError] exception if the [buffer] is not large enough to
+  /// hold the bytes. That is, if the length of the [buffer] after the [offset]
+  /// is less than 16.
+  static String unparse(List<int> buffer, {int offset = 0}) {
+    if (buffer.length - offset < 16) {
+      throw RangeError('buffer too small: need 16: length=${buffer.length}'
+          '${offset != 0 ? ', offset=$offset' : ''}');
+    }
+    var i = offset;
+    return '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}'
+        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}-'
+        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}-'
+        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}-'
+        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}-'
+        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}'
+        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}'
+        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}';
+  }
+
+  static List<int> _parse(String uuid,
+      List<int>? buffer,
+      int offset) {
     var i = offset, ii = 0;
 
     // Get buffer to store the result
@@ -84,47 +182,5 @@ class UuidParsing {
     }
 
     return buffer;
-  }
-
-  ///Parses the provided [uuid] into a list of byte values as a Uint8List.
-  /// Can optionally be provided a [buffer] to write into and
-  ///  a positional [offset] for where to start inputting into the buffer.
-  /// Throws FormatException if the UUID is invalid. Optionally you can set
-  /// [validate] to false to disable validation of the UUID before parsing.
-  static Uint8List parseAsByteList(String uuid,
-      {List<int>? buffer,
-      int offset = 0,
-      bool validate = true,
-      ValidationMode validationMode = ValidationMode.strictRFC9562,
-      bool noDashes = false}) {
-    return Uint8List.fromList(parse(uuid,
-        buffer: buffer,
-        offset: offset,
-        validate: validate,
-        validationMode: validationMode,
-        noDashes: noDashes));
-  }
-
-  /// Unparses a [buffer] of bytes and outputs a proper UUID string.
-  /// An optional [offset] is allowed if you want to start at a different point
-  /// in the buffer.
-  ///
-  /// Throws a [RangeError] exception if the [buffer] is not large enough to
-  /// hold the bytes. That is, if the length of the [buffer] after the [offset]
-  /// is less than 16.
-  static String unparse(List<int> buffer, {int offset = 0}) {
-    if (buffer.length - offset < 16) {
-      throw RangeError('buffer too small: need 16: length=${buffer.length}'
-          '${offset != 0 ? ', offset=$offset' : ''}');
-    }
-    var i = offset;
-    return '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}'
-        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}-'
-        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}-'
-        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}-'
-        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}-'
-        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}'
-        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}'
-        '${_byteToHex[buffer[i++]]}${_byteToHex[buffer[i++]]}';
   }
 }

--- a/lib/uuid.dart
+++ b/lib/uuid.dart
@@ -105,6 +105,49 @@ class Uuid {
         validationMode: validationMode);
   }
 
+  /// Parses the provided [uuid] into a list of byte values as a List&lt;int&gt;.
+  /// Can optionally be provided a [buffer] to write into and
+  ///  a positional [offset] for where to start inputting into the buffer.
+  /// Throws FormatException if the UUID format is invalid.
+  /// No validation is performed on the content of the uuid.
+  /// Optionally you can set [validate] to false to disable
+  /// validation of the UUID before parsing.
+  ///
+  /// Example parsing a UUID string
+  ///
+  /// ```dart
+  /// var bytes = uuid.parse('797ff043-11eb-11e1-80d6-510998755d10');
+  /// // bytes-> [121, 127, 240, 67, 17, 235, 17, 225, 128, 214, 81, 9, 152, 117, 93, 16]
+  /// ```
+  static List<int> parseHex128(
+    String uuid, {
+    List<int>? buffer,
+    int offset = 0,
+    bool validate = true
+  }) {
+    return UuidParsing.parseHex128(uuid,
+        buffer: buffer,
+        offset: offset,
+        validate: validate);
+  }
+
+  /// Parses the provided [uuid] into a list of byte values as a Uint8List.
+  /// Can optionally be provided a [buffer] to write into and
+  ///  a positional [offset] for where to start inputting into the buffer.
+  /// Throws FormatException if the UUID is invalid.
+  /// No validation is performed on the content of the uuid.
+  /// Optionally you can set [validate] to false to disable
+  /// validation of the UUID before parsing.
+  static Uint8List parseHex128AsByteList(String uuid,
+      {List<int>? buffer,
+      int offset = 0,
+      bool validate = true}) {
+    return UuidParsing.parseHex128AsByteList(uuid,
+        buffer: buffer,
+        offset: offset,
+        validate: validate);
+  }
+
   /// Unparses a [buffer] of bytes and outputs a proper UUID string.
   /// An optional [offset] is allowed if you want to start at a different point
   /// in the buffer.
@@ -133,6 +176,21 @@ class Uuid {
         fromString: fromString,
         fromByteList: fromByteList,
         validationMode: validationMode,
+        noDashes: noDashes);
+  }
+
+  /// Validates the provided [uuid] to be a 128 bits
+  /// representation and returns a [bool]
+  /// No validation is performed on the content of the uuid
+  /// You can choose to validate from a string or from a byte list based on
+  /// which parameter is passed.
+  static bool isValidUUIDFormat(
+      {String fromString = '',
+      Uint8List? fromByteList,
+      bool noDashes = false}) {
+    return UuidValidation.isValidUUIDFormat(
+        fromString: fromString,
+        fromByteList: fromByteList,
         noDashes: noDashes);
   }
 

--- a/lib/uuid_value.dart
+++ b/lib/uuid_value.dart
@@ -63,6 +63,16 @@ class UuidValue {
     return uuidValue;
   }
 
+  /// withFormatValidation() creates a UuidValue from a [uuid] string.
+  /// Throws [FormatException] if the UUID format is invalid.
+  /// No validation is performed on the content of the uuid.
+  factory UuidValue.withFormatValidation(String uuid,
+      [bool noDashes = false]) {
+    final uuidValue = UuidValue.fromString(uuid);
+    uuidValue.validateFormat(noDashes);
+    return uuidValue;
+  }
+
   /// Creates a UuidValue by taking directly the internal string representation of the [uuid],
   /// which is expected to be lowercase.
   ///
@@ -86,6 +96,14 @@ class UuidValue {
       bool noDashes = false]) {
     UuidValidation.isValidOrThrow(
         fromString: uuid, validationMode: validationMode, noDashes: noDashes);
+  }
+
+  /// validateFormat() validates the internal string representation format of the uuid.
+  /// Throws [FormatException] if the UUID format is invalid.
+  void validateFormat(
+      [bool noDashes = false]) {
+    UuidValidation.isValidFormatOrThrow(
+        fromString: uuid, noDashes: noDashes);
   }
 
   // toBytes() converts the internal string representation to a list of bytes.

--- a/lib/validation.dart
+++ b/lib/validation.dart
@@ -57,6 +57,15 @@ class UuidValidation {
           final match = regex.hasMatch(fromString.toLowerCase());
           return match;
         }
+      case ValidationMode.loose:
+        {
+          var pattern = (noDashes)
+              ? r'^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32})$'
+              : r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+          final regex = RegExp(pattern, caseSensitive: false, multiLine: true);
+          final match = regex.hasMatch(fromString.toLowerCase());
+          return match;
+        }
     }
   }
 
@@ -65,7 +74,8 @@ class UuidValidation {
   /// You can choose to validate from a string or from a byte list based on
   /// which parameter is passed.
   /// Optionally you can set [validationMode] to `ValidationMode.nonStrict` to
-  /// allow for non RFC4122 compliant UUIDs.
+  /// allow for non RFC4122 compliant UUIDs, or to `ValidationMode.loose` to
+  /// allow any 128 bit uuid-like id (e.g. ulid or future versions of uuid).
   /// If you are using a Microsoft GUID, you should set [validationMode] to
   /// `ValidationMode.nonStrict`.
   static void isValidOrThrow(
@@ -91,6 +101,18 @@ class UuidValidation {
         if (isValidNonStrict) {
           throw FormatException(
               'The provided UUID is not RFC4122 compliant. It seems you might be using a Microsoft GUID. Try setting `validationMode = ValidationMode.nonStrict`',
+              fromString);
+        }
+
+        final isValidLoose = isValidUUID(
+            fromString: fromString,
+            fromByteList: fromByteList,
+            validationMode: ValidationMode.loose,
+            noDashes: noDashes);
+
+        if (isValidLoose) {
+          throw FormatException(
+              'The provided UUID is not RFC4122 compliant. Try setting `validationMode = ValidationMode.loose`',
               fromString);
         }
       }

--- a/lib/validation.dart
+++ b/lib/validation.dart
@@ -57,16 +57,28 @@ class UuidValidation {
           final match = regex.hasMatch(fromString.toLowerCase());
           return match;
         }
-      case ValidationMode.loose:
-        {
-          var pattern = (noDashes)
-              ? r'^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32})$'
-              : r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
-          final regex = RegExp(pattern, caseSensitive: false, multiLine: true);
-          final match = regex.hasMatch(fromString.toLowerCase());
-          return match;
-        }
     }
+  }
+
+  /// Validates the provided [uuid] to be a 128 bits
+  /// representation and returns a [bool]
+  /// No validation is performed on the content of the uuid
+  /// You can choose to validate from a string or from a byte list based on
+  /// which parameter is passed.
+  static bool isValidUUIDFormat(
+      {String fromString = '',
+      Uint8List? fromByteList,
+      bool noDashes = false}) {
+    if (fromByteList != null) {
+      fromString = UuidParsing.unparse(fromByteList);
+    }
+
+      var pattern = (noDashes)
+          ? r'^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32})$'
+          : r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+      final regex = RegExp(pattern, caseSensitive: false, multiLine: true);
+      final match = regex.hasMatch(fromString.toLowerCase());
+      return match;
   }
 
   /// Validates the provided [uuid] to make sure it has all the necessary
@@ -74,8 +86,7 @@ class UuidValidation {
   /// You can choose to validate from a string or from a byte list based on
   /// which parameter is passed.
   /// Optionally you can set [validationMode] to `ValidationMode.nonStrict` to
-  /// allow for non RFC4122 compliant UUIDs, or to `ValidationMode.loose` to
-  /// allow any 128 bit uuid-like id (e.g. ulid or future versions of uuid).
+  /// allow for non RFC4122 compliant UUIDs.
   /// If you are using a Microsoft GUID, you should set [validationMode] to
   /// `ValidationMode.nonStrict`.
   static void isValidOrThrow(
@@ -103,21 +114,28 @@ class UuidValidation {
               'The provided UUID is not RFC4122 compliant. It seems you might be using a Microsoft GUID. Try setting `validationMode = ValidationMode.nonStrict`',
               fromString);
         }
-
-        final isValidLoose = isValidUUID(
-            fromString: fromString,
-            fromByteList: fromByteList,
-            validationMode: ValidationMode.loose,
-            noDashes: noDashes);
-
-        if (isValidLoose) {
-          throw FormatException(
-              'The provided UUID is not RFC4122 compliant. Try setting `validationMode = ValidationMode.loose`',
-              fromString);
-        }
       }
 
       throw FormatException('The provided UUID is invalid.', fromString);
+    }
+  }
+
+  /// Validates the provided [uuid] to be a 128 bits
+  /// representation and returns a [bool]
+  /// No validation is performed on the content of the uuid
+  /// You can choose to validate from a string or from a byte list based on
+  /// which parameter is passed.
+  static void isValidFormatOrThrow(
+      {String fromString = '',
+      Uint8List? fromByteList,
+      bool noDashes = false}) {
+    final isValid = isValidUUIDFormat(
+        fromString: fromString,
+        fromByteList: fromByteList,
+        noDashes: noDashes);
+
+    if (!isValid) {
+      throw FormatException('The provided UUID has an invalid format.', fromString);
     }
   }
 }

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -211,10 +211,6 @@ void main() {
       var isValidNonStrict = Uuid.isValidUUID(
           fromString: guidString, validationMode: ValidationMode.nonStrict);
       expect(isValidNonStrict, true);
-
-      var isValidLoose = Uuid.isValidUUID(
-          fromString: guidString, validationMode: ValidationMode.loose);
-      expect(isValidLoose, true);
     });
   });
 
@@ -576,15 +572,19 @@ void main() {
       expect(uuidval.uuid, validGUID.toLowerCase());
     });
 
-    test('Pass valid Ulid to constructor with validation mode loose', () {
+    test('Pass valid Ulid to constructor with format validation', () {
       const validUlid = '019f13f5-53cb-b219-ca3e-4b569376f32b';
       expect(
           Uuid.isValidUUID(
-              fromString: validUlid, validationMode: ValidationMode.loose),
+              fromString: validUlid),
+          false);
+      expect(
+          Uuid.isValidUUIDFormat(
+              fromString: validUlid),
           true);
 
       final uuidval =
-          UuidValue.withValidation(validUlid, ValidationMode.loose);
+          UuidValue.withFormatValidation(validUlid);
       expect(uuidval.uuid, validUlid.toLowerCase());
     });
 

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -211,6 +211,10 @@ void main() {
       var isValidNonStrict = Uuid.isValidUUID(
           fromString: guidString, validationMode: ValidationMode.nonStrict);
       expect(isValidNonStrict, true);
+
+      var isValidLoose = Uuid.isValidUUID(
+          fromString: guidString, validationMode: ValidationMode.loose);
+      expect(isValidLoose, true);
     });
   });
 
@@ -570,6 +574,18 @@ void main() {
       final uuidval =
           UuidValue.withValidation(validGUID, ValidationMode.nonStrict);
       expect(uuidval.uuid, validGUID.toLowerCase());
+    });
+
+    test('Pass valid Ulid to constructor with validation mode loose', () {
+      const validUlid = '019f13f5-53cb-b219-ca3e-4b569376f32b';
+      expect(
+          Uuid.isValidUUID(
+              fromString: validUlid, validationMode: ValidationMode.loose),
+          true);
+
+      final uuidval =
+          UuidValue.withValidation(validUlid, ValidationMode.loose);
+      expect(uuidval.uuid, validUlid.toLowerCase());
     });
 
     test('const namespace regression catcher', () {


### PR DESCRIPTION
Solves #146

Add `ValidationMode.loose` which validates only the string to represent a 128 bit number, and nothing more.

Use cases:
- future proof parsing: allow parsing future versions of uuid without needing to update the dependency to this library;
- parse other uuid-like ids, like ulids;
- parse manually crafted mnemonic uuids (e.g. `deadbeef-cafe-babe-c0de-feedfacade00`), very useful for testing purposes.

In summary, when we need an id of 128 bit and we are not interested in how it is generated.

In general it could be risky to validate more than needed. For this reason many languages validate an uuid only to be a 128 bit number representation, and do not validate the version from which the uuid is generated. This PR brings the possibility to achieve this also in dart.