### PR TITLE
Add a monotonic UUIDv7 generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Features:
 
 * Generate RFC4122 version 1, version 4, or version 5 UUIDs
 * Supports RFC9562 version 6, version 7, and version 8
+* Optional monotonic version 7 generator
 * Runs in web, server, and flutter
 * Cryptographically strong random number generation on all platforms
 * Validate and parse generic 128-bit hexadecimal values without enforcing UUID version or variant bits
@@ -22,7 +23,7 @@ Features:
 1. Open a command line and cd to your projects root folder
 2. In your pubspec, add an entry for dart-uuid to your dependencies (example below)
 3. pub install
-4. If you wish to run tests, go into packages/dart-uuid/ and run 'dart test/uuid_test.dart'
+4. If you wish to run tests, go into packages/dart-uuid/ and run 'dart test'
 
 ### Pubspec
 
@@ -64,6 +65,43 @@ Uuid.parseHex128(value); // 16 bytes
 const withoutDashes = '019f13f553cbb219ca3e4b569376f32b';
 Uuid.parseHex128(withoutDashes, noDashes: true); // 16 bytes
 ```
+
+### Monotonic v7
+
+`uuid.v7()` fills everything after the millisecond timestamp with random bits,
+so ids created in the same millisecond have no defined order. `UuidV7Monotonic`
+replaces the most significant of those random bits with a 16-bit counter
+(RFC 9562 §6.2, Method 1), so ids from one generator sort in creation order
+under an ordinary string comparison (or byte comparison if parsed).
+
+```dart
+import 'package:uuid/uuid.dart';
+import 'package:uuid/v7monotonic.dart';
+
+// Plain v7, both created in the same millisecond. Creation order and sort
+// order happen to disagree.
+const uuid = Uuid();
+uuid.v7(); // -> '019fcd85-9fac-7f64-8711-97a4665f1adc'
+uuid.v7(); // -> '019fcd85-9fac-715d-80d0-556404fa23ea'
+
+// Monotonic, also within one millisecond. The counter defines the order.
+final generator = UuidV7Monotonic();
+generator.generate(); // -> '019fcd85-9fb3-7488-a625-f7a830c2dcf7'
+generator.generate(); // -> '019fcd85-9fb3-7488-a87c-0c31456d733b'
+```
+
+Import the generator directly; it is not exported from `uuid.dart`.
+
+Some limits of the monotonic generator:
+
+1. Ordering only holds within one generator instance. v7 cannot order
+   concurrent generators against each other without shared state.
+2. Ids strictly increase unless the clock moves backward by more than 10
+   seconds, which resets ordering to the new clock reading. Ids stay unique
+   across the reset.
+3. Ids are not secret tokens. The counter increments by exactly +1 within a
+   millisecond, so an observer holding one id can predict the next. Use v4
+   if unguessability matters.
 
 ## Documentation
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 import 'package:uuid/data.dart';
 import 'package:uuid/uuid.dart';
 import 'package:uuid/rng.dart';
+import 'package:uuid/v7monotonic.dart';
 
 void main() {
   var uuid = Uuid();
@@ -81,6 +82,14 @@ void main() {
     0x67
   ])); // -> '1e1041c7-10b9-662e-9234-0123456789ab'
 
+  // Generate monotonic v7 ids, which sort in creation order even when created
+  // within the same millisecond
+  final mono = UuidV7Monotonic();
+  var mono1 =
+      mono.generate(); // -> e.g., '019fcd85-9fb3-7488-a625-f7a830c2dcf7'
+  var mono2 =
+      mono.generate(); // -> e.g., '019fcd85-9fb3-7488-a87c-0c31456d733b'
+
   print('v1        | $v1');
   print('v1 exact  | $v1Exact');
   print('v4        | $v4');
@@ -92,4 +101,6 @@ void main() {
   print('v7 exact  | $v7Exact');
   print('v8        | $v8');
   print('v8 exact  | $v8Exact');
+  print('v7 mono 1 | $mono1');
+  print('v7 mono 2 | $mono2');
 }

--- a/lib/v7monotonic.dart
+++ b/lib/v7monotonic.dart
@@ -1,0 +1,339 @@
+import 'dart:typed_data';
+
+import 'package:uuid/data.dart';
+
+import 'v7.dart';
+
+/// A persisted generator checkpoint: the `(millisec, counter)` carried by the
+/// last-generated UUIDv7.
+typedef UuidV7Checkpoint = ({int millisec, int counter});
+
+/// Pluggable cross-restart state hook (RFC 9562 §6.3).
+///
+/// [UuidV7Monotonic] is monotonic within an instance. [load] runs at
+/// construction and [save] runs with each new UUID generation, so the
+/// [UuidV7Checkpoint] carries forward to a new generator built afterward with
+/// the same [UuidV7State] instance.
+///
+/// Since [load] runs *only* at construction, a running generator never reads
+/// state back. As a result: (1) no implementation of this hook can share state
+/// among concurrently running generators; and (2) implementations MAY batch or
+/// debounce writes, since an un-flushed write cannot regress monotonicity.
+///
+/// The default [InMemoryUuidV7State] keeps state in memory only. Persisting and
+/// restoring the [UuidV7Checkpoint] across isolates or restarts is left to the
+/// consumer. Extend with a durable persistence implementation that suits your
+/// application if that would address a problem you have.
+abstract class UuidV7State {
+  /// Last persisted checkpoint, or null on first run.
+  UuidV7Checkpoint? load();
+
+  /// Record the checkpoint from the most recently generated UUIDv7.
+  void save(int millisec, int counter);
+}
+
+/// In-memory [UuidV7State]: no system I/O and no state beyond this object's
+/// lifetime (ends with the process and does not span isolates).
+class InMemoryUuidV7State implements UuidV7State {
+  UuidV7Checkpoint? _state;
+
+  @override
+  UuidV7Checkpoint? load() => _state;
+
+  @override
+  void save(int millisec, int counter) =>
+      _state = (millisec: millisec, counter: counter);
+}
+
+/// Stateful, monotonic UUIDv7 generator (after RFC 9562 §6.2): a 16-bit
+/// counter in the most-significant random bits (`rand_a` then `rand_b`) ahead
+/// of a 58-bit random tail.
+///
+/// The counter increments on UUIDv7s generated in the same millisecond,
+/// allowing UUIDs to increase in creation order. Unlike `Uuid().v7()`, which
+/// fills everything after the millisecond timestamp with random, UUIDv7s from
+/// this generator sort by creation order within a same-millisecond batch under,
+/// for example, `ORDER BY id` (raw big-endian octet / canonical lowercase-hex
+/// comparison).
+///
+/// The generator is not exported from `uuid.dart`; import this library.
+///
+/// ```dart
+/// import 'package:uuid/v7monotonic.dart';
+///
+/// final generator = UuidV7Monotonic();
+/// // sorts via the counter within the same millisecond
+/// generator.generate(); // -> '019fcd85-9fb3-7488-a625-f7a830c2dcf7'
+/// generator.generate(); // -> '019fcd85-9fb3-7488-a87c-0c31456d733b'
+/// ```
+///
+/// Does not provide strict monotonicity *across* generators, which UUIDv7
+/// cannot provide without shared generator state.
+///
+/// The embedded timestamp and counter reveal the creation time and order of a
+/// UUIDv7 by design (RFC 9562 §8, Security Considerations). The counter
+/// increments by exactly +1 between consecutive ids sharing a timestamp (RFC
+/// 9562 §6.2 Method 1), so an observer holding one id knows both fields of the
+/// next, leaving the 58-bit random tail as its only unpredictable part. Prefer
+/// UUIDv4 if unguessability is vital for your use case.
+///
+/// UUIDs from one generator strictly increase in creation order as long as the
+/// system clock does not move backward by more than 10 seconds. A backward move
+/// larger than that (such as a manual clock change or a time sync on a device
+/// with a very stale or dead clock) resets ordering to the new clock reading.
+/// UUIDs stay unique across that reset.
+///
+/// A UUID's timestamp differs from the previously generated UUID's when the
+/// clock has passed it, when the counter overflows within a millisecond, or
+/// when the clock jumps backward by more than 10 seconds. Each such change (a
+/// "tick") randomly seeds the counter's start. The top bit is an overflow
+/// guard, so whatever the seed draw, a tick has at least 2^15 = 32,768
+/// additional same-millisecond UUIDs before the counter rolls over. After that,
+/// the generator borrows from the next millisecond to get a new tick. UUIDs
+/// stay monotonic and unique at the cost of a timestamp that briefly leads the
+/// wall clock.
+///
+/// The counter is per-instance, so running more isolates does not consume any
+/// single counter faster. Regarding collision resistance across generator
+/// instances, same-millisecond ids from two generators are separated by the
+/// 15-bit counter seed plus the remaining 58-bit random tail.
+///
+/// https://www.rfc-editor.org/rfc/rfc9562.html
+class UuidV7Monotonic {
+  /// Counter step for a pin: a fixed +1, RFC 9562 §6.2 Method 1
+  /// ("Fixed-Length Dedicated Counter Bits").
+  static const int _pinStep = 1;
+
+  /// Largest backward clock movement, in milliseconds, that is absorbed rather
+  /// than obeyed.
+  ///
+  /// A backward step within the allowance (e.g. an NTP correction) is *pinned*:
+  /// the generator keeps the last emitted timestamp and climbs the counter
+  /// instead of minting an out-of-order id. A jump beyond it is *honored* by
+  /// resetting to the clock, so the generator is not permanently stranded ahead
+  /// of real time.
+  static const int _rollbackAllowanceMs = 10000;
+
+  /// Exclusive counter bound = `2^16`. The 16-bit counter spans `0 .. 65535`;
+  /// reaching this value means the tick's counter must roll over.
+  static const int _counterCeiling = 65536;
+
+  final int Function() _nowMs;
+  final UuidV7State _state;
+
+  /// Source of the random bits. Null falls back to [V7State.random].
+  final GlobalOptions? goptions;
+
+  /// Last *emitted* timestamp. May run ahead of the wall clock after an
+  /// overflow-borrow.
+  int _lastMs;
+
+  /// Last *accepted raw* `nowMs()` reading. The rollback allowance magnitude is
+  /// measured against this, not [_lastMs], so benign borrow run-ahead (where
+  /// `_lastMs > clock` legitimately) is not misread as a backward clock jump.
+  /// Set to the last emitted timestamp from persisted state, when present, on
+  /// load; see edge case caveat in the assignment at the end of the constructor
+  /// body.
+  int _lastObserved;
+
+  int _counter;
+
+  /// Build a stateful UUIDv7 generator that remains monotonic even within a
+  /// single millisecond.
+  ///
+  /// [nowMs] supplies the clock (injectable for tests); defaults to
+  /// `DateTime.timestamp().millisecondsSinceEpoch` (UTC).
+  ///
+  /// [goptions] supplies the random bits through [GlobalOptions.rng]. Defaults
+  /// to [V7State.random].
+  ///
+  /// [state] is a cross-restart persistence hook (defaults to in-memory via
+  /// [InMemoryUuidV7State]).
+  UuidV7Monotonic({
+    int Function()? nowMs,
+    this.goptions,
+    UuidV7State? state,
+  })  : _nowMs = nowMs ?? (() => DateTime.timestamp().millisecondsSinceEpoch),
+        _state = state ?? InMemoryUuidV7State(),
+        _lastMs = -1,
+        _lastObserved = -1,
+        _counter = 0 {
+    // Load persisted state once, after which in-memory fields are
+    // authoritative.
+    final seed = _state.load();
+    if (seed != null) {
+      _lastMs = seed.millisec;
+      _counter = seed.counter;
+    }
+    // Seed _lastObserved from the (possibly restored) _lastMs. The checkpoint
+    // persists only (millisec, counter), not the raw-clock history, so on a
+    // restart we have no real observed reading and use the restored emitted
+    // timestamp as a conservative proxy. The first post-restart mint then
+    // measures backwards rollback against where the generator left off. A clock
+    // reading earlier than that is pinned rather than honored (NB. up to
+    // _rollbackAllowanceMs) to preserve generator monotonicity.
+    //
+    // Caveat (should be a rare edge case). _lastObserved is meant to track the
+    // raw clock so that a borrow-ahead (where a same-ms counter overflow bumped
+    // _lastMs past raw clock time) is not mistaken for the clock jumping
+    // backwards. But the checkpoint persists no raw-clock history, so if the
+    // generator was last running borrowed-ahead (_lastMs > the clock at save
+    // time), the restored _lastMs carries that borrow-ahead and we seed
+    // _lastObserved from it. For the first post-restart mint only, the rollback
+    // magnitude is then measured against a borrowed (too-high) reference
+    // instead of a true clock reading.
+    //
+    // Concretely: with _lastObserved seeded B ms ahead of real time (B for
+    // borrow), a clock reading `now` is treated as a backward jump of
+    // `(_lastObserved - now)`, inflated by B compared to the real jump
+    // `(_lastObserved - now - B)`. At the threshold (_rollbackAllowanceMs), and
+    // only at that threshold, a `now` whose true backward delta is just under
+    // _rollbackAllowanceMs but whose inflated delta exceeds it gets reset to
+    // `now` when it would otherwise have been pinned, with the consequence that
+    // one id may sort out of order at the boundary. After the first mint,
+    // _lastObserved is overwritten with a real raw clock reading and the
+    // guarantee is restored. B is the borrow depth at save, and that is more
+    // likely driven by a clock stall than by mint rate. (Could not exceed
+    // 2,400 mints/ms when writing this implementation on a MacBook Pro M5.)
+    // So the borrow depth is large only with a stuck clock. Eliminating it
+    // entirely would require also persisting _lastObserved. Judge this not
+    // worth the extra write for a boundary-only, self-correcting effect.
+    //
+    // On a start with no persisted state, this does nothing. (_lastMs is
+    // still -1 and so is _lastObserved.)
+    _lastObserved = _lastMs;
+  }
+
+  /// Generate the next monotonic UUIDv7 as a canonical lowercase-hex string.
+  String generate() {
+    // One RNG draw per mint. Passed to `UuidV7.generate` as randomBytes so we
+    // own the whole post-timestamp tail. The draw is 16 bytes but a UUIDv7's
+    // tail is only 10; the `v7` implementation copies only bytes 0-9
+    // specifically of the passed randomBytes. Since the last 6 bytes never
+    // reach the id, we spend two of them (10-11) as a 16-bit fresh-tick counter
+    // seed. This keeps the seed independent of the random tail that does
+    // survive. The current counter mark is then overlaid onto bytes 0-9 in
+    // `_overlayCounter`.
+    final rb = (goptions?.rng ?? V7State.random).generate();
+    _advance(rb);
+    // Delegate the 48-bit timestamp packing, version/variant stamping, and
+    // formatting to UuidV7.
+    return const UuidV7()
+        .generate(options: V7Options(_lastMs, _overlayCounter(rb, _counter)));
+  }
+
+  /// Advance the clock and counter state for one mint, updating [_lastMs] and
+  /// [_counter] and mirroring them to [_state]. A fresh tick seeds the counter
+  /// from the spare tail of [rb] (random bytes 10–11; see [generate]).
+  void _advance(Uint8List rb) {
+    final now = _nowMs();
+    // backwardMs is measured against _lastObserved (last real clock reading),
+    // not _lastMs (the emitted timestamp), which a borrow can run ahead of the
+    // clock. Compared against _rollbackAllowanceMs only when the clock is not
+    // ahead of the last emitted timestamp _lastMs (i.e. the first branch
+    // didn't fire).
+    //
+    // A worked run-ahead example: after a borrow, _lastMs = 1005,
+    // _lastObserved = 1000, and the clock has since ticked to now = 1003:
+    //
+    //   now > _lastMs?   1003 > 1005 == false (already emitted 1005)
+    //   backwardMs = (1000 - 1003) <= allowance,
+    //   so pin and climb from emitted 1005
+    //
+    // The negative value just means the clock has passed its old reading but
+    // not yet the emitted high-water mark.
+    final backwardMs = _lastObserved - now;
+    if (now > _lastMs) {
+      // Wall clock at/ahead of the last emitted timestamp => new, later tick.
+      _lastMs = now;
+      _counter = _freshTick(rb);
+    } else if (backwardMs <= _rollbackAllowanceMs) {
+      // Three cases: (1) same ms, (2) NTP or other backwards jitter within
+      // allowance, or (3) benign borrow run-ahead. All cases stay monotonic by
+      // pinning to the emitted timestamp and climbing the counter by _pinStep.
+      _counter += _pinStep;
+
+      // On overflow, borrow the next millisecond, and restart the counter from
+      // a fresh tick rather than a pin step. _lastMs may now lead the wall
+      // clock; backwardMs is measured against _lastObserved, not _lastMs, so
+      // any lead is not misread as a backward clock jump (see above).
+      if (_counter >= _counterCeiling) {
+        _lastMs += 1;
+        _counter = _freshTick(rb);
+      }
+    } else {
+      // Large backward jump (e.g. TZ-correlated re-sync) exceeding
+      // _rollbackAllowanceMs. Honor it so we are not permanently stranded.
+      // Reorder happens across the boundary, but this is a rare case; while the
+      // reset replays already-used timestamps, uniqueness is preserved by the
+      // random seed & tail.
+      _lastMs = now;
+      _counter = _freshTick(rb);
+    }
+    _lastObserved = now;
+    _state.save(_lastMs, _counter);
+  }
+
+  /// Counter value for a fresh tick: a 15-bit random seed, with the 16-bit
+  /// counter's top bit always 0 as an overflow guard. At least half the range
+  /// therefore remains as burst headroom no matter where the seed lands.
+  ///
+  /// The seed is drawn from [rb]'s spare tail (bytes 10–11). The UUID never
+  /// uses those bytes, keeping the seed independent of the random tail that
+  /// does survive into the UUID.
+  int _freshTick(Uint8List rb) {
+    // Combine the two bytes into one 16-bit value. rb[10] goes first via
+    // byte shift up into bits 8–15, which leaves bits 0–7 zeroed. The OR
+    // drops rb[11] into that gap.
+    final seed16 = (rb[10] << 8) | rb[11];
+
+    // Mask off the high bit 15 (0x7FFF == 0111_1111_1111_1111) as the overflow
+    // guard, so _counterCeiling is always at least 2^15 increments away.
+    return seed16 & 0x7FFF;
+  }
+
+  /// Overlay the 16-bit [counter] onto [rb] in place and return it.
+  /// [UuidV7.generate] copies [rb]'s first 10 bytes into uuid bytes 6–15, so
+  /// `rb[i]` is uuid byte `6 + i`.
+  ///
+  /// The counter occupies, from MSB to LSB, the 12 bits of `rand_a` (uuid bits
+  /// 52–63), then 4 bits of `rand_b` resuming at uuid bit 66 (skipping the
+  /// variant at 64–65), where c0 is the least significant counter bit:
+  ///
+  /// ```text
+  ///        rb[0]            rb[1]            rb[2]
+  ///   uuid byte 6      uuid byte 7      uuid byte 8
+  ///   ver | c15..c12   c11 ....... c4   var | c3..c0 | rand_b...
+  ///   4     4          8                2     4        2
+  /// ```
+  ///
+  /// The & masks below preserve every non-counter bit on [rb], including the
+  /// random tail: `0xF0` keeps the version nibble and `0xC3` keeps the variant
+  /// bits and the 2 random-tail bits at the end of byte 8. [UuidV7.generate]
+  /// stamps version (byte 6 high nibble) and variant (byte 8 high 2 bits) after
+  /// copying the bytes returned from this method.
+  Uint8List _overlayCounter(Uint8List rb, int counter) {
+    // uuid bits 52–55 take c15..c12. Shift the counter down 12 so its top
+    // nibble sits in bits 3–0; `& 0x0F` is a no-op after shift given counter <
+    // 2^16, kept to state the field width. `rb[0] & 0xF0` clears the low nibble
+    // to write the counter while preserving the version nibble above it.
+    rb[0] = (rb[0] & 0xF0) | ((counter >> 12) & 0x0F);
+
+    // uuid bits 56–63 take c11..c4. Shift the counter down 4 to drop c3..c0,
+    // leaving c15..c4; `& 0xFF` then trims c15..c12, which were written above.
+    // (Storing into a Uint8List truncates to 8 bits anyway, but here too, mask
+    // explicitly to state the field width.)
+    rb[1] = (counter >> 4) & 0xFF;
+
+    // uuid bits 66–69 take c3..c0, mid-byte. Byte 8 is `vv cccc tt`: variant,
+    // counter nibble, random tail. Each operand fills one part and the OR
+    // merges:
+    //
+    //   (counter & 0x0F) << 2   00 cccc 00   cap clears vv, shift clears tt
+    //   rb[2] & 0xC3            vv 0000 tt   keeps variant & 2 random tail bits
+    //                           -----------
+    //                           vv cccc tt
+    rb[2] = (rb[2] & 0xC3) | ((counter & 0x0F) << 2);
+    return rb;
+  }
+}

--- a/test/v7monotonic_test.dart
+++ b/test/v7monotonic_test.dart
@@ -1,0 +1,377 @@
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:uuid/data.dart';
+import 'package:uuid/uuid.dart';
+import 'package:uuid/v7monotonic.dart';
+import 'package:uuid/rng.dart';
+import 'package:uuid/v7.dart';
+
+/// Package RNG configuration wired to a seeded RNG.
+GlobalOptions _seeded(int seed) => GlobalOptions(MathRNG(seed: seed));
+
+/// An [RNG] that returns the same byte in all 16 positions. Fully deterministic
+/// test input with no dependence on any particular seed's output.
+class _ConstRNG implements RNG {
+  const _ConstRNG(this.byte);
+  final int byte;
+  @override
+  Uint8List generate() => Uint8List(16)..fillRange(0, 16, byte);
+}
+
+/// RNG configuration whose RNG fills every random byte with [byte].
+GlobalOptions _fixed(int byte) => GlobalOptions(_ConstRNG(byte));
+
+/// A [UuidV7State] that restores a fixed checkpoint and discards saves, so a
+/// generator under test can start at any arbitrary `(millisec, counter)`.
+/// (NB. [UuidV7Monotonic] calls [load] once, at construction.)
+class _PreloadedState implements UuidV7State {
+  const _PreloadedState(this._checkpoint);
+  final UuidV7Checkpoint _checkpoint;
+  @override
+  UuidV7Checkpoint? load() => _checkpoint;
+  @override
+  void save(int millisec, int counter) {}
+}
+
+/// UUIDv7 version nibble (canonical position: first char of the 3rd group).
+int _version(String id) => int.parse(id[14], radix: 16);
+
+/// Top nibble of the 4th group, whose high 2 bits carry the variant.
+int _variantNibble(String id) => int.parse(id[19], radix: 16);
+
+/// The 48-bit `unix_ts_ms` field, RFC 9562 §5.7: a big-endian unsigned count
+/// of milliseconds since the Unix Epoch (canonical position: the 1st and 2nd
+/// groups, 32 + 16 bits). This is the *emitted* timestamp, so it may run ahead
+/// of the wall clock after an overflow-borrow.
+int _timestampMs(String id) =>
+    // end is exclusive, so the hyphen at index 8 is skipped
+    int.parse(id.substring(0, 8) + id.substring(9, 13), radix: 16);
+
+bool _strictlyIncreasing(List<String> ids) {
+  for (var i = 1; i < ids.length; i++) {
+    if (!(ids[i].compareTo(ids[i - 1]) > 0)) return false;
+  }
+  return true;
+}
+
+List<String> _mint(UuidV7Monotonic g, int n) =>
+    List.generate(n, (_) => g.generate());
+
+void main() {
+  group('[Format Tests]', () {
+    test('every id is a well-formed v7 with correct variant', () {
+      final g = UuidV7Monotonic(goptions: _seeded(1));
+      for (final id in _mint(g, 50)) {
+        expect(
+          Uuid.isValidUUIDFormat(fromString: id),
+          isTrue,
+          reason: '$id is not a canonical 8-4-4-4-12 hex layout',
+        );
+        expect(_version(id), 7, reason: 'version nibble must be 7');
+        // variant 10xx => nibble in 0x8..0xb
+        expect(_variantNibble(id), inInclusiveRange(0x8, 0xb));
+      }
+    });
+
+    test('the 16-bit counter lands in rand_a and the top of rand_b', () {
+      // A golden test for the byte overlay: where the counter bits go,
+      // and that the bits around them survive.
+      //
+      // Restoring (1000, 0x5A59) against a clock frozen at 1000 makes the first
+      // mint pin at counter 0x5A5A == 0101 1010 0101 1010. The alternating
+      // nibbles mean that every counter bit differs from its neighbors, so
+      // an off-by-one shift or a swapped mask moves a 0 where a 1 belongs and
+      // shows up in the golden string.
+      //
+      //   uuid byte 6 = 0111 0101   version 7, then counter bits 15-12 (0101)
+      //   uuid byte 7 = 1010 0101   counter bits 11-4
+      //   uuid byte 8 = 10 1010 xx  variant 10, counter bits 3-0, 2 random
+      //
+      // Since rand_a takes the top 12 counter bits (5a5), the two trailing bits
+      // of byte 8 are the only RNG-decided bits in the counter region. Run both
+      // RNG polarities (all 0s, all 1s) to nail those down. Also show that
+      // the untouched tail (uuid bytes 9-15) passes through whole.
+      String firstPinnedId(int rngByte) => UuidV7Monotonic(
+            nowMs: () => 1000,
+            goptions: _fixed(rngByte),
+            state: const _PreloadedState((millisec: 1000, counter: 0x5A59)),
+          ).generate();
+
+      // Timestamp 1000 == 0x3e8. With an all-zero tail, byte 8 is 1010 1000.
+      expect(firstPinnedId(0x00), '00000000-03e8-75a5-a800-000000000000');
+      // With an all-ones tail, byte 8 is 1010 1011, with the same counter bits,
+      // and the version and variant stamps still land on top of RNG all-1s.
+      expect(firstPinnedId(0xFF), '00000000-03e8-75a5-abff-ffffffffffff');
+    });
+  });
+
+  group('[Ordering Tests]', () {
+    test('same-ms burst sorts in mint order', () {
+      final g = UuidV7Monotonic(
+        nowMs: () => 1000, // frozen clock → forces the same-ms path
+        goptions: _seeded(2),
+      );
+      final ids = _mint(g, 500);
+      expect(_strictlyIncreasing(ids), isTrue);
+      final sorted = [...ids]..sort();
+      expect(sorted, equals(ids), reason: 'sorted order == mint order');
+    });
+
+    test('advancing clock keeps ids increasing', () {
+      var t = 1000;
+      final g = UuidV7Monotonic(nowMs: () => t++, goptions: _seeded(3));
+      expect(_strictlyIncreasing(_mint(g, 200)), isTrue);
+    });
+
+    test('a fresh tick seeds the counter below the overflow guard bit', () {
+      // The fresh-tick seed is 15 bits, leaving the 16-bit counter's top bit
+      // clear as an overflow guard. With an all-0xFF RNG a 16-bit read
+      // would be 0xFFFF, while the guard makes the seed exactly 0x7FFF. Read
+      // the counter's top 12 bits (rand_a, the three hex digits after the
+      // version nibble).
+      final g = UuidV7Monotonic(nowMs: () => 1000, goptions: _fixed(0xFF));
+      // No restored state, so the first mint takes the fresh-tick branch.
+      final randA = int.parse(g.generate().substring(15, 18), radix: 16);
+      expect(randA & 0x800, 0, reason: 'guard bit must be clear');
+      expect(randA, 0x7FF, reason: 'the seed is exactly the 15 low bits');
+    });
+  });
+
+  group('[Clock Regression Tests]', () {
+    test('small backward step within allowance is pinned (monotonic)', () {
+      // Clock jumps back 5ms after the first mint — within the 10s allowance.
+      final clock = [1000, 995, 996, 997, 998];
+      var i = 0;
+      final g = UuidV7Monotonic(
+        nowMs: () => clock[i < clock.length ? i++ : clock.length - 1],
+        goptions: _seeded(4),
+      );
+      expect(_strictlyIncreasing(_mint(g, 5)), isTrue);
+    });
+
+    test('large backward jump beyond allowance is honored (not stranded)', () {
+      // First mint at a high time, then the clock resets far back (> allowance).
+      var t = 10000000;
+      final g = UuidV7Monotonic(
+        nowMs: () => t,
+        goptions: _seeded(5),
+      );
+      final first = g.generate();
+      t = 5000; // jump back well beyond the allowance
+      final second = g.generate();
+      // Honored: the new id reflects the lower clock (sorts before the first),
+      // proving the generator reset rather than pinning to the old timestamp.
+      expect(second.compareTo(first) < 0, isTrue);
+    });
+
+    test('the allowance is exactly 10s, inclusive', () {
+      // The run-ahead test in [Overflow Tests] draws its clock reading from
+      // this boundary. A change to the allowance would alter the validity
+      // of its assertions. Pin the library-private constant value: a step back
+      // of exactly 10000ms is inside the allowance and pins to the emitted
+      // timestamp, while 10001ms is outside and is honored.
+      int secondTimestampAfterStepBack(int backMs) {
+        var t = 20000; // only has to exceed the step backs below
+        final g = UuidV7Monotonic(nowMs: () => t, goptions: _seeded(6));
+        g.generate();
+        t = 20000 - backMs;
+        return _timestampMs(g.generate());
+      }
+
+      expect(secondTimestampAfterStepBack(10000), 20000,
+          reason: '10000ms back is within the allowance: clock pinned');
+      expect(secondTimestampAfterStepBack(10001), 9999,
+          reason: '10001ms back exceeds the allowance: clock honored');
+    });
+  });
+
+  group('[Overflow Tests]', () {
+    test('counter overflow borrows the ms and never throws', () {
+      // Restore the generator two pins short of the 2^16 ceiling. The first
+      // mint pins to 65535 and the second exhausts the counter. The all-0xFF
+      // RNG reseeds that borrow at the highest guarded value, 0x7FFF, which is
+      // the worst case for reaching a second overflow in this burst.
+      //
+      // The preload is written against the ceiling, so it also pins the counter
+      // width: a wider counter would not overflow here at all, a narrower one
+      // would have overflowed already, and either moves the borrow off index 1.
+      const overflowAt = 1;
+      final g = UuidV7Monotonic(
+        nowMs: () => 1000, // frozen => only a borrow can keep ids increasing
+        goptions: _fixed(0xFF),
+        state: const _PreloadedState((millisec: 1000, counter: 65534)),
+      );
+      final ids = _mint(g, 10);
+      expect(_strictlyIncreasing(ids), isTrue);
+      expect(ids.every((id) => _version(id) == 7), isTrue);
+      // The clock never moves, so the emitted timestamp must step exactly at
+      // the overflow. A generator that borrowed on every pin would also stay
+      // ordered and stamp a valid version, but would leave the last id at 1010
+      // (1000 start + 10 mints).
+      expect(_timestampMs(ids[overflowAt - 1]), 1000);
+      expect(_timestampMs(ids[overflowAt]), 1001, reason: 'borrowed one ms');
+      expect(_timestampMs(ids.last), 1001, reason: 'borrowed exactly once');
+    });
+
+    test('borrow run-ahead is not misclassified as a backward jump', () {
+      // An overflow borrow pushes the emitted timestamp 1ms past the clock.
+      // Every mint after it must still pin, because the rollback magnitude is
+      // read against _lastObserved (the last raw clock reading) rather than
+      // _lastMs (which borrowed).
+      //
+      // Those two references differ by exactly the borrow depth, so they only
+      // disagree about a clock reading whose distance from _lastObserved falls
+      // within the depth of the generator's fixed 10s rollback allowance, that
+      // is, in (10000 - depth, 10000] ms. Given a 1ms borrow that is a single
+      // reading, 10000ms below the last observed one. Reading 10000 against
+      // _lastObserved = 20000 gives 10000, inside the allowance, so the correct
+      // implementation pins; incorrectly reading it against _lastMs = 20001
+      // would give 10001, outside the allowance.
+      //
+      // The discrimination assumption only holds while the allowance is 10s;
+      // see test 'the allowance is exactly 10s, inclusive'.
+      //
+      // An incorrect implementation honors the jump and emits at 10000, sorting
+      // before the already-emitted 20001. Away from that boundary both take the
+      // same branch: a nearer reading pins under either measurement, while a
+      // further one is honored under either.
+      //
+      // Start the generator two pins short of the 2^16 ceiling. The first mint
+      // pins to 65535 and the second exhausts the counter, borrowing from 20000
+      // to 20001 ms. The all-0xFF RNG puts that reseed at the highest guarded
+      // value, 0x7FFF: the guard bit caps the seed there, so even in this worst
+      // case the ceiling is 32769 pins away. A second 1ms borrow (which would
+      // move the emitted timestamp for reasons unrelated to the branch under
+      // test) is therefore far out of reach across the 8 mints that follow. The
+      // clock drops backward to the discriminating reading of 10000 from the
+      // third mint on.
+      var mints = 0;
+      final g = UuidV7Monotonic(
+        nowMs: () => mints++ < 2 ? 20000 : 10000,
+        goptions: _fixed(0xFF),
+        state: const _PreloadedState((millisec: 20000, counter: 65534)),
+      );
+      final ids = _mint(g, 10);
+      expect(_strictlyIncreasing(ids), isTrue);
+      // The borrow puts the generator in the run-ahead state, so assert it
+      // happened where expected.
+      expect(_timestampMs(ids[0]), 20000);
+      expect(_timestampMs(ids[1]), 20001,
+          reason: 'counter exhausted, borrowed');
+      // Every mint after the borrow keeps the borrowed timestamp: shows the pin
+      // branch was taken. The honor branch would reset to 10000.
+      expect(_timestampMs(ids.last), 20001);
+    });
+
+    test('the guard bit guarantees 2^15 same-ms mints after a fresh tick', () {
+      // The two tests above take the ceiling from a preloaded counter; this
+      // one mints UUIDs up to it.
+      //
+      // The all-0xFF RNG seeds a fresh tick at the highest guarded value,
+      // 0x7FFF (32767), the worst case for headroom. From there the 16-bit
+      // counter has 65536 - 32767 = 32769 slots, the fresh-tick mint itself
+      // plus 2^15 = 32768 pins. So indices 0..32768 all share the frozen
+      // timestamp and index 32769 is the first to borrow.
+      //
+      // This fails if the counter width changes, if the pin step stops being
+      // +1, or if the guard bit is dropped.
+      final g = UuidV7Monotonic(nowMs: () => 1000, goptions: _fixed(0xFF));
+      final ids = _mint(g, 32770);
+      expect(_strictlyIncreasing(ids), isTrue);
+      expect(_timestampMs(ids[32768]), 1000, reason: '2^15 pins still fit');
+      expect(_timestampMs(ids[32769]), 1001, reason: 'the next one borrows');
+    });
+  });
+
+  group('[Default RNG Tests]', () {
+    // Every other test injects _seeded(n) or _fixed(n), which sets
+    // goptions.rng, so the `goptions?.rng ?? V7State.random` fallback is never
+    // taken. But a caller who passes no goptions at all runs exactly that
+    // fallback. Exercise it with no injected RNG.
+    test(
+      'default construction (no injected RNG) mints valid, increasing ids',
+      () {
+        final g = UuidV7Monotonic(
+          nowMs: () => 1000,
+        ); // real V7State.random
+        final ids = _mint(g, 50);
+        expect(_strictlyIncreasing(ids), isTrue);
+        expect(ids.every((id) => _version(id) == 7), isTrue);
+      },
+    );
+  });
+
+  group('[RandomBytes Contract Tests]', () {
+    // The single-draw design seeds the fresh-tick counter from bytes 10–15 of
+    // the 16-byte RNG draw, trusting that v7 consumes only randomBytes[0..9] (a
+    // UUID's 10-byte tail). That keeps the seed disjoint from the random tail
+    // that survives into the id. If another change ever widened the read, the
+    // seed would correlate with the emitted tail, which would be a bug. Pin the
+    // expected behavior so we'd find out.
+    test('v7 reads only randomBytes[0..9]; bytes 10-15 never reach the id', () {
+      const v7 = UuidV7();
+      final base = List<int>.generate(
+        16,
+        (i) => i + 1,
+      ); // ints from 1-16 -- distinct and nonzero
+      final reference = v7.generate(options: V7Options(1000, base));
+      // mutate random draw tail
+      for (var i = 10; i < 16; i++) {
+        final mutated = [...base]..[i] ^= 0xFF; // flip every bit of byte i
+        // check assertion in every iteration
+        expect(
+          v7.generate(options: V7Options(1000, mutated)),
+          equals(reference),
+          reason:
+              'mutating randomBytes[$i] changed the Uiidv7 -- mutation leaked '
+              'into the tail, breaking the disjoint counter-seed assumption',
+        );
+      }
+    });
+
+    test('v7 does read randomBytes[0..9]', () {
+      const v7 = UuidV7();
+      final base = List<int>.generate(
+        16,
+        (i) => i + 1,
+      ); // ints from 1-16 -- distinct and nonzero
+      final reference = v7.generate(options: V7Options(1000, base));
+      // randomBytes[1] is uuid byte 7: fully random, no version/variant stamp,
+      // so flipping it must change the id (proves the differential test above
+      // could actually observe a leak).
+      final mutated = [...base]..[1] ^= 0xFF;
+      expect(
+        v7.generate(options: V7Options(1000, mutated)),
+        isNot(equals(reference)),
+      );
+    });
+  });
+
+  group('[Cross-Restart State Tests]', () {
+    test(
+        'a new generator sharing state continues monotonically even with an '
+        'earlier (within-allowance) clock', () {
+      final state = InMemoryUuidV7State();
+      final genA = UuidV7Monotonic(
+        nowMs: () => 1000,
+        goptions: _seeded(11),
+        state: state,
+      );
+      final aIds = _mint(genA, 10);
+
+      // "Restart": new generator, same persisted state, clock a few ms earlier.
+      final genB = UuidV7Monotonic(
+        nowMs: () => 996,
+        goptions: _seeded(12),
+        state: state, // loaded once in B's constructor
+      );
+      final firstB = genB.generate();
+      expect(
+        firstB.compareTo(aIds.last) > 0,
+        isTrue,
+        reason: 'B continues after A despite the earlier clock reading',
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Add a monotonic UUIDv7 generator

Closes #144.

`uuid.v7()` fills everything after the millisecond timestamp with random bits, so ids minted in the same millisecond have no defined order. `UuidV7Monotonic` replaces the most significant of those bits with a
16-bit counter (RFC 9562 §6.2, Method 1). Ids from one generator then sort in creation order under an ordinary string or byte comparison.

```dart
import 'package:uuid/v7monotonic.dart';

final generator = UuidV7Monotonic();
generator.generate(); // -> '019fcd85-9fb3-7488-a625-f7a830c2dcf7'
generator.generate(); // -> '019fcd85-9fb3-7488-a87c-0c31456d733b'
```

Imported like the other versions, and did not touch `uuid.dart`. Named following the `v8generic.dart` precedent rather than the `MonotonicUuidV7Generator` in the issue.

Going down your checklist from #144:

**"In-memory state only at first."** Only implemented `InMemoryUuidV7State` against the `UuidV7State` hook. Turned out to be very useful in the tests, where I could restore a generator at an arbitrary `(millisec, counter)` to start two increments below the overflow ceiling instead of generating 2^15 ids.

**"Fixed or very limited counter configuration."** All private constants; design discussion below. Constructor params limited to clock, RNG, and state hook, all optional with the natural defaults.

**"Clear docs: monotonic only..."** Specifically, monotonic "only within this generator instance / isolate / process." Stated upfront in a new README section on the monotonic counter, and in the class dartdoc.

**"Not guaranteed across app restarts."** With the hook shipped, we can say ordering survives a restart only if the consumer supplies a durable `UuidV7State`, and the package supplies only the in-memory one. In the class dartdoc.

**"Not for secret tokens."** Stated in the README section, plus a paragraph in the class dartdoc citing the RFC §8 and the limits of the selected counter design.

**"Strong tests."** See below.

## Selected Defaults

| Setting | Value | Why |
| --- | --- | --- |
| counter width | 16 bits | Leaves a 58-bit random tail |
| counter step | +1 | RFC 9562 §6.2 Method 1 |
| fresh-tick seed | random, guard bit clear | Floors same-ms headroom at 2^15; separates concurrent generators |
| counter overflow | borrow the next millisecond | No busy-wait; ids stay monotonic and unique, at the cost of a timestamp that briefly leads the clock |
| clock rollback allowance | 10s | Follows LiosK's `uuidv7` (JS), `uuid7` (Rust), and `uuidv7.h` (C) |

Performance cost is about 1.04× non-monotonic `v7()` on my HW (Apple M5, Dart 3.11.4). Re: counter width, I measured under ~2400 mints/ms, and a 16-bit counter guarantees 2^15 same-ms ids, which is about an order of magnitude of headroom. Anything wider would spend more random tail bits to raise an already high ceiling. (And more tail bits reduce guessability, notwithstanding the caveat about these tokens not being meant for secrets.)

I kept the benchmark harness out of the PR. Happy to send it along if you want.

Counter step +1 was simplest. Contemplated a random counter increment, but it does not help with collision resistance any more than the fresh-tick seed and we are not promising unguessability.

Busy-wait on overflow seemed incompatible with practical use cases, especially for Flutter and especially on mobile. Can share more if needed.

## Tests

15 new tests. In order down the test file.

| Checklist test item | Covered by |
| --- | --- |
| UUID validity | well-formed v7 with correct variant; golden test pinning where all 16 counter bits land |
| same-ms ordering | burst sorts in mint order; advancing clock keeps ids increasing; fresh tick seeds below the guard bit |
| clock rollback | small backward step pinned; large jump honored, not stranded; allowance is exactly 10s, inclusive |
| counter overflow | overflow borrows the ms; borrow run-ahead isn't misread as a backward jump; guard bit guarantees 2^15 same-ms mints |
| other tests | test without injected RNG; hold the `v7` randomBytes contract that only bytes 0..9 reach the id; state hook test |
| dart2js/wasm-safe math | see below |

Re: the web-safe math, most of the id is written using the existing `v7` path. With a 16-bit counter, every shift in the overlay is well under 32 bits by inspection. I ran the suite under both web compilers locally and it passes as-is. Let me know if you see cases we should guard via test.

## Discussion

The state hook has subtle interactions with the clock rollback allowance. First, since a backward clock jump past the 10s allowance is honored, that lowers the high-water mark for a consumer implementing durable state. That then does permit a reorder across the restart. This is unavoidable if we are shipping both a state hook and a clock rollback allowance.

Another consequence happens because I seed `_lastObserved` from potentially restored state. There's a boundary case where, on the first mint after a restore, a generator that was running ahead of the clock can measure a rollback against an inflated reference. It self-corrects on the next UUID. There is a long inline comment about this.

It's possible a future consumer with durable state would rather the generator never honor a backward jump at all, pinning indefinitely and letting the timestamp lead the clock. Rather more precisely -- such a consumer would take responsibility for their own clock, and we would offer no opinion about it. Both of these consequences then disappear. I'd leave this alone for now.

I know this is a large PR compared to the package size, and speaking of long comments, I can see the comment density is well above your house style. That's personal preference on code I found subtle to get right, and I also felt it would speed your review to keep it in. Happy to trim it down at any point if it reads as noise.

Since I know it's a sensitive topic for many OSS maintainers, I wanted to mention that I have used AI assistance in preparing this. The design and decisions are mine.
